### PR TITLE
Fix parameter deploys

### DIFF
--- a/stack-deploy/src/types.rs
+++ b/stack-deploy/src/types.rs
@@ -378,10 +378,10 @@ impl ParameterMap {
     ///         ParameterKey(String::from("key-b")),
     ///         ParameterValue(String::from("value-b2"))
     ///     ),]))
-    ///     .to_parameter_update_parameters(&existing_stack),
+    ///     .to_update_parameters(&existing_stack),
     /// )
     /// ```
-    pub fn to_parameter_update_parameters(
+    pub fn to_update_parameters(
         &self,
         existing_stack: &aws_sdk_cloudformation::types::Stack,
     ) -> Vec<aws_sdk_cloudformation::types::Parameter> {
@@ -406,91 +406,6 @@ impl ParameterMap {
                 })
                 .collect(),
         }
-    }
-
-    /// To template update parameters
-    ///
-    /// ### Examples
-    ///
-    /// Some updates
-    ///
-    /// ```
-    /// # use stack_deploy::types::*;
-    ///
-    /// let template = Template::Plain {
-    ///     body: String::from("ununsed"),
-    ///     parameter_keys: ParameterKeys::from([ParameterKey(String::from("key-a"))]),
-    /// };
-    ///
-    /// assert_eq!(
-    ///     vec![
-    ///         aws_sdk_cloudformation::types::Parameter::builder()
-    ///             .parameter_key("key-a")
-    ///             .use_previous_value(true)
-    ///             .build(),
-    ///         aws_sdk_cloudformation::types::Parameter::builder()
-    ///             .parameter_key("key-b")
-    ///             .parameter_value("value-b")
-    ///             .build(),
-    ///     ],
-    ///     ParameterMap(std::collections::BTreeMap::from([(
-    ///         ParameterKey(String::from("key-b")),
-    ///         ParameterValue(String::from("value-b"))
-    ///     ),]))
-    ///     .to_template_update_parameters(template.parameter_keys()),
-    /// )
-    /// ```
-    pub fn to_template_update_parameters(
-        &self,
-        template_parameter_keys: &ParameterKeys,
-    ) -> Vec<aws_sdk_cloudformation::types::Parameter> {
-        self.to_parameter_keys()
-            .union(template_parameter_keys)
-            .map(|key| {
-                let builder =
-                    aws_sdk_cloudformation::types::Parameter::builder().parameter_key(&key.0);
-
-                match self.0.get(key) {
-                    Some(value) => builder.parameter_value(value.0.clone()),
-                    None => builder.use_previous_value(true),
-                }
-                .build()
-            })
-            .collect()
-    }
-
-    /// To parameter keys
-    ///
-    /// ### Examples
-    ///
-    /// ```
-    /// # use stack_deploy::types::*;
-    ///
-    /// let template = Template::Plain {
-    ///     body: String::from("ununsed"),
-    ///     parameter_keys: ParameterKeys::from([ParameterKey(String::from("key-a"))]),
-    /// };
-    ///
-    /// assert_eq!(
-    ///     ParameterKeys::from([
-    ///         ParameterKey(String::from("key-a")),
-    ///         ParameterKey(String::from("key-b")),
-    ///     ]),
-    ///     ParameterMap(std::collections::BTreeMap::from([
-    ///         (
-    ///             ParameterKey(String::from("key-a")),
-    ///             ParameterValue(String::from("value-a"))
-    ///         ),
-    ///         (
-    ///             ParameterKey(String::from("key-b")),
-    ///             ParameterValue(String::from("value-b"))
-    ///         ),
-    ///     ]))
-    ///     .to_parameter_keys()
-    /// )
-    /// ```
-    pub fn to_parameter_keys(&self) -> ParameterKeys {
-        ParameterKeys::from_iter(self.0.keys().cloned())
     }
 }
 


### PR DESCRIPTION
* Turns out the distinction between parameter and template updates does not have to go down to the level of the parameter map.
* Fixes parameter deploys to actually not set the recent template.