### PR TITLE
Change to improved stack API

### DIFF
--- a/stack-deploy/src/cli.rs
+++ b/stack-deploy/src/cli.rs
@@ -122,7 +122,7 @@ mod instance {
                 Self::Watch { name } => {
                     crate::instance_spec::InstanceSpec::watch(
                         cloudformation,
-                        crate::stack::fetch_stack_id(cloudformation, &name.0).await,
+                        crate::stack::load_stack_id(cloudformation, name).await,
                     )
                     .await
                 }

--- a/stack-deploy/src/instance_spec.rs
+++ b/stack-deploy/src/instance_spec.rs
@@ -19,7 +19,7 @@ pub struct InstanceSpec {
 impl InstanceSpec {
     pub async fn delete(&self, cloudformation: &aws_sdk_cloudformation::client::Client) {
         let client_request_token = ClientRequestToken::generate();
-        let stack_id = crate::stack::fetch_stack_id(cloudformation, &self.stack_name.0).await;
+        let stack_id = crate::stack::load_stack_id(cloudformation, &self.stack_name).await;
 
         cloudformation
             .delete_stack()

--- a/stack-deploy/src/types.rs
+++ b/stack-deploy/src/types.rs
@@ -2,6 +2,10 @@
 pub struct StackName(pub String);
 pub struct OutputKey(pub String);
 
+pub trait StackIdentifier: std::fmt::Debug {
+    fn as_str(&self) -> &str;
+}
+
 impl std::str::FromStr for StackName {
     type Err = &'static str;
 
@@ -16,12 +20,30 @@ impl From<&StackName> for String {
     }
 }
 
+impl StackIdentifier for StackName {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl StackIdentifier for &StackName {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct StackId(pub String);
 
 impl From<&StackId> for String {
     fn from(value: &StackId) -> Self {
         value.0.clone()
+    }
+}
+
+impl StackIdentifier for &StackId {
+    fn as_str(&self) -> &str {
+        &self.0
     }
 }
 


### PR DESCRIPTION
* Avoid primitive parameters
* Do not use the term `fetch` for remote interactions when most fetch functions actually work against local data structures.