### PR TITLE
Fix pg-ephemeral to only terminate client backends

### DIFF
--- a/pg-ephemeral/CHANGELOG.md
+++ b/pg-ephemeral/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- Suppress spurious `PID N is not a PostgreSQL backend process` warnings when
+  committing a container. Connection termination now targets only client
+  backends instead of every entry in `pg_stat_activity`, which also included
+  background workers and auxiliary processes.
+
 ## 0.2.3
 
 ### Breaking Changes

--- a/pg-ephemeral/src/container.rs
+++ b/pg-ephemeral/src/container.rs
@@ -333,7 +333,7 @@ impl Container {
 
     async fn terminate_connections(&self) -> Result<(), Error> {
         self.apply_sql(
-            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid()",
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND backend_type = 'client backend'",
         )
         .await
         .map_err(Error::TerminateConnections)


### PR DESCRIPTION
`terminate_connections` previously ran `pg_terminate_backend` against every row in `pg_stat_activity`, which includes background workers, the checkpointer, autovacuum launcher, etc. PostgreSQL emits a `PID N is not a PostgreSQL backend process` warning for each of those, cluttering logs during container commit.

Restrict the query to `backend_type = 'client backend'` so only user sessions are targeted.