### PR TITLE
Release git-proc 0.4.0 and pg-client 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "git-proc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cmd-proc",
  "thiserror 2.0.18",
@@ -2946,7 +2946,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pg-client"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "cmd-proc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ comfy-table = "7"
 dirs = "6"
 env_logger = "0.11"
 fluent-uri = { version = "0.4", features = ["net"] }
-git-proc = { version = "0.3.0", path = "git-proc" }
+git-proc = { version = "0.4.0", path = "git-proc" }
 google-cloud-gax = "1"
 google-cloud-sql-v1 = "2"
 hex = "0.4.3"
@@ -53,7 +53,7 @@ mmigration = { path = "mmigration" }
 nom = "8"
 nom-language = "0.1"
 ociman = { version = "0.4.0", path = "ociman" }
-pg-client = { version = "0.2.0", path = "pg-client", features = ["sqlx"] }
+pg-client = { version = "0.3.0", path = "pg-client", features = ["sqlx"] }
 pg-ephemeral = { version = "0.3.0", path = "pg-ephemeral" }
 pretty_assertions = "1.4"
 prettyplease = "0.2"

--- a/git-proc/CHANGELOG.md
+++ b/git-proc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.0
+
+### Breaking Changes
+
+- Update to `cmd-proc` 0.5.0. `cmd_proc::Command` and `cmd_proc::CommandError`
+  are re-exposed through public API (`status()` return types on `add`,
+  `clone`, `config`, `init`, `worktree`, and `build()` / `test_eq()` accessors),
+  so the struct-to-enum shape change in `cmd-proc` 0.5.0 is a breaking change
+  for git-proc consumers as well.
+
 ## 0.3.0
 
 ### Breaking Changes

--- a/git-proc/Cargo.toml
+++ b/git-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-proc"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true

--- a/pg-client/CHANGELOG.md
+++ b/pg-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.3.0
+
+### Breaking Changes
+
+- Update to `cmd-proc` 0.5.0. `cmd_proc::EnvVariableName` is re-exposed through
+  the public `PG*` constants (`PGAPPNAME`, `PGHOST`, `PGPORT`, ...) and the
+  `sqlx` module API, so the `cmd-proc` 0.5.0 upgrade is a breaking change for
+  pg-client consumers: any caller that also depends on `cmd-proc` 0.4.0 will
+  see type-identity mismatches on these constants.
+
 ## 0.2.0
 
 Separate transport configuration from session/auth configuration.

--- a/pg-client/Cargo.toml
+++ b/pg-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-client"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

- Bump `git-proc` 0.3.0 → 0.4.0 and `pg-client` 0.2.0 → 0.3.0.
- Both crates re-expose `cmd_proc::` types in their public API, so the earlier `cmd-proc` 0.5.0 release is a breaking change that propagates through them. Without this pass, `cargo publish -p pg-ephemeral` fails verification because the crates.io-hosted `git-proc 0.3.0` and `pg-client 0.2.0` still pin `cmd-proc ^0.4.0`, producing two `cmd_proc` crates in the dependency graph and type-identity mismatches on `EnvVariableName` / `CommandError`.
- Changelogs document the breakage:
  - `git-proc`: `Command`, `CommandError` leak via `status()` / `build()` / `test_eq()`.
  - `pg-client`: `EnvVariableName` leaks via the `PG*` constants and the `sqlx` module API.
- Unblocks the pending `pg-ephemeral 0.3.0` publish (its tag will be re-created at the merged HEAD once this lands and both crates are on crates.io).