### PR TITLE
Add apple/container support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,11 @@ jobs:
       if: ${{ matrix.lane.name == 'apple' }}
       run: |
         nix develop --command bash -c '
+          cleanup() {
+            container system stop || true
+          }
+          trap cleanup EXIT
+          cleanup
           yes | container system start
           OCIMAN_BACKEND=apple cargo --verbose nextest run --all-features --release --package ociman --test integration --test-threads=1
         '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,13 +145,19 @@ jobs:
         - name: non-ociman
         - name: podman
         - name: docker
-        # non-ociman tests also run on macOS; the ociman lanes are linux-only (they early-return on macOS).
+        # non-ociman tests also run on macOS; Linux ociman lanes use Docker/Podman,
+        # while Apple gets a dedicated runner with Apple Container available.
         include:
         - os:
             cargo_build_target: aarch64-apple-darwin
             version: macos-15
           lane:
             name: non-ociman
+        - os:
+            cargo_build_target: aarch64-apple-darwin
+            version: aarch64-darwin
+          lane:
+            name: apple
     name: Test ${{ matrix.lane.name }} (${{ matrix.os.cargo_build_target }})
     runs-on: ${{ matrix.os.version }}
     env:
@@ -164,12 +170,14 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - if: ${{ matrix.lane.name != 'apple' }}
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.rustup
         key: ${{ matrix.os.version }}-rustup-${{ matrix.os.cargo_build_target }}-${{ hashFiles('rust-toolchain.toml') }}
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - if: ${{ matrix.lane.name != 'apple' }}
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.cargo/bin/
@@ -177,11 +185,13 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/registry/index/
         key: ${{ matrix.os.version }}-cargo-${{ matrix.os.cargo_build_target }}-${{ hashFiles('.github/workflows/ci.yml', '**/Cargo.lock', 'rust-toolchain.toml') }}
-    - name: Install nextest
+    - if: ${{ matrix.lane.name != 'apple' }}
+      name: Install nextest
       uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
       with:
         tool: cargo-nextest
-    - name: Download nextest archive
+    - if: ${{ matrix.lane.name != 'apple' }}
+      name: Download nextest archive
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: nextest-archive-${{ matrix.os.cargo_build_target }}
@@ -189,6 +199,7 @@ jobs:
     # (gated on rdeps(ociman)) runs the manager binary extracted from the archive via
     # MANAGER_PULL_BIN, so it never recompiles manager.
     - name: Run tests
+      if: ${{ matrix.lane.name != 'apple' }}
       env:
         MANAGER_PULL_BIN: ${{ github.workspace }}/target/pull-test-images-manager
         LANE: ${{ matrix.lane.name }}
@@ -206,6 +217,13 @@ jobs:
           docker) export OCIMAN_BACKEND=docker ;;
         esac
         cargo --verbose nextest run --archive-file nextest-archive.tar.zst --extract-to . --workspace-remap . --filter-expr "$filter" $threads
+    - name: Run ociman Apple integration tests
+      if: ${{ matrix.lane.name == 'apple' }}
+      run: |
+        nix develop --command bash -c '
+          yes | container system start
+          OCIMAN_BACKEND=apple cargo --verbose nextest run --all-features --release --package ociman --test integration --test-threads=1
+        '
 
   ruby-integration-test:
     # Workaround for Bundler 4.x failing when attempting to install gems to the

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782760764,
+        "narHash": "sha256-N66fYdUuZ9hpdM7jsQ7CUWtLJduqGDyTGCaLR62CXaQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7a1a64774a5fd0b0cd39ac95d0e170ace8b266a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7a1a64774a5fd0b0cd39ac95d0e170ace8b266a0",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "mrs development environment (ociman Apple integration)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/7a1a64774a5fd0b0cd39ac95d0e170ace8b266a0";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+    in
+    {
+      devShells.aarch64-darwin.default = pkgs.mkShell {
+        packages = with pkgs; [
+          rustup
+          cargo-nextest
+        ];
+
+        RUST_BACKTRACE = "full";
+      };
+    };
+}

--- a/ociman/APPLE_BACKEND.md
+++ b/ociman/APPLE_BACKEND.md
@@ -1,0 +1,310 @@
+# Apple Container Backend
+
+- macOS-only; requires macOS 26 and Apple Container 1.0.0. The version is detected and recorded but not gated — no behavior branches on it.
+- Goal: `pg-ephemeral` runs correctly on the Apple backend.
+- Uses the released `container` CLI, parses Apple JSON, and fails early on unsupported features.
+
+## Compatibility Boundaries
+
+- Do not reshape Apple inspect JSON as a public or internal contract.
+- Do not implement Go-template rendering for Apple commands.
+
+## Relationship to Containerization Framework
+
+Apple `container` is built on the Swift
+[`apple/containerization`](https://github.com/apple/containerization) framework, which grounds two assumptions here: it requires macOS 26 (matching the ociman Apple backend gate), and its EXT4/archive/OCI APIs are what make the commit emulation (below) workable.
+
+The backend targets the released `container` CLI; the framework is
+treated as background evidence, not a dependency.
+
+## Backend Shape
+
+The backend is a single enum. Apple carries only a version; it has no
+`rootless` field because Apple Container has no rootless/rootful split:
+
+```rust
+pub enum Backend {
+    Docker { version: semver::Version, rootless: bool },
+    Podman { version: semver::Version, rootless: bool },
+    Apple { version: semver::Version },
+}
+```
+
+There is no separate backend-kind type. Every unsupported-feature error
+is only ever constructed on the Apple path, so those messages hardcode
+`"apple"` rather than carrying a backend value, and backend checks use
+`matches!(backend, Backend::Apple { .. })`.
+
+## Selection
+
+Extend backend selection with `apple` only:
+
+```sh
+OCIMAN_BACKEND=apple
+```
+
+and config:
+
+```toml
+default_backend = "apple"
+```
+
+- `OCIMAN_BACKEND=apple` — strict: resolve Apple or return the Apple error.
+- `default_backend = "apple"` — preferred: Apple, then Docker, then Podman.
+- `default_backend = "auto"` — Docker, then Podman, then Apple last.
+
+Apple is tried last in auto-detection: discoverable when it's the only runtime, never displacing an available Docker/Podman.
+
+## Supported Surface
+
+The Apple backend supports:
+
+- **Resolution & readiness** — macOS-only resolution/version detection, with clear errors for non-macOS selection and macOS older than 26; `container system status --format json` readiness check with a not-running error and start hint.
+- **Containers** — run, exec, stop, and delete/force-delete (canonical Apple `container delete`); inspect (raw Apple JSON); typed labels, name/id (preserving user-provided names), and published-host-port lookup; host directory/file mounts where the released CLI exposes supported semantics; list via Apple JSON, including by-label via client-side filtering (key-only and exact-match).
+- **Images** — inspect, labels, presence check, tag, delete (canonical Apple command); pull with Apple-aware not-found classification; push via `container image push`, surfacing runtime/registry errors clearly; build from a directory and from inline instructions via a temporary-directory fallback (see "Build").
+- **Networking** — default network subnet inspection on macOS 26.
+
+## Explicitly Unsupported
+
+The backend fails early with domain errors for:
+
+- `Container::inspect_format` on Apple Container: returns `InspectError::FormatUnsupported`. `pg-ephemeral` does not need it.
+- Docker/Podman rootless semantics; `is_rootless()` returns `false`
+- host aliases such as `host.docker.internal`; Apple host reachability should use the default network gateway from Apple network inspect output
+- unsupported pull policy flags, if Apple CLI does not accept equivalent flags
+- list format templates on Apple commands
+- label filters on Apple CLI commands
+
+## API/Error Changes
+
+Where a subprocess-level error could not distinguish an unsupported feature from a command failure, the API carries an explicit public domain error variant instead.
+
+### Commit
+
+`commit` returns a domain error instead of a raw `CommandError`:
+
+```rust
+pub enum CommitError {
+    Inspect(InspectError),
+    MissingAppleBaseImage,
+    Command(CommandError),
+}
+```
+
+On Apple, `commit` dispatches to an export-and-build emulation (see
+"Commit emulation" below); the `Inspect` and `MissingAppleBaseImage`
+variants surface its failure modes.
+
+### Inspect Format
+
+`inspect_format` on Apple returns an explicit unsupported variant:
+
+```rust
+pub enum InspectError {
+    FormatUnsupported,
+    // existing variants...
+}
+```
+
+No Go-template rendering. If a caller needs a value from `inspect_format`, add a typed ociman API for it instead.
+
+### Host Resolution
+
+Apple host reachability is resolved through the default network gateway (`.status.ipv4Gateway`, see "Network subnets").
+
+## Implementation Seams
+
+### 1. Command construction
+
+`Backend::command()` returns `container` for Apple; individual operations construct the flags they need.
+
+The run-definition-to-command translation can fail for unsupported Apple options before subprocess execution, so the public run command builder is fallible:
+
+```rust
+pub fn to_cmd_proc_command(&self) -> Result<Command, RunError>
+```
+
+`run()` and `run_detached()` use `self.to_cmd_proc_command()?`, and Apple returns `RunError::UnsupportedOption { option }` when a configured run option has no supported Apple equivalent (currently `pull_policy`).
+
+Command differences:
+
+- Docker/Podman remove: `container rm`; Apple remove: `container delete`.
+- Docker/Podman list format: Go templates; Apple list format: `json`, `yaml`, `toml`, `table`.
+
+### 2. Inspect parsing
+
+Raw inspect stays backend-specific; portability comes from typed APIs. Docker/Podman share common-field parsing; Apple uses its own field names, parsed separately.
+
+Contracts preserved:
+
+- `Backend::inspect_container([id])` → JSON array (Apple objects wrapped and looped per id — no batch inspect).
+- `Container::inspect()` → the single raw Apple object from that array.
+- `Backend::inspect_image(reference)` → the one raw Apple image object.
+
+Typed APIs parse by backend:
+
+- Docker/Podman labels: `.Config.Labels`
+- Apple container labels: `.configuration.labels`
+- Docker/Podman ports: `.NetworkSettings.Ports["5432/tcp"][0].HostPort`
+- Apple ports: `.configuration.publishedPorts[]`
+- Docker name: `.Name` with leading slash stripped
+- Podman name: `.Name`
+- Apple name/id: prefer an explicit user-provided name field if Apple exposes one; only fall back to ID if Apple has no separate name concept in inspect/list
+
+### 3. Container listing
+
+`Backend::container_list(format, filters)` remains the Docker/Podman list seam.
+
+Apple uses a typed internal primitive parsed from `container list --all
+--format json`:
+
+```rust
+struct AppleRecord {
+    id: ContainerId,
+    name: Option<String>,
+    labels: BTreeMap<String, String>,
+}
+```
+
+This is Apple-specific; Docker/Podman keep their existing `container_list`
+seam.
+
+Apple label filtering is client-side. Both ociman label filter forms are supported: key-only existence and exact key/value matching. Apple list JSON includes labels, so filtering runs directly on list output rather than inspecting each container.
+
+### 4. Image and container presence
+
+Apple image presence uses:
+
+```sh
+container image inspect <reference>
+```
+
+Success means present, missing image means absent, and other failures surface as errors. Apple container presence uses container inspect the same way.
+
+Apple has no distinct exit codes for absence, so missing images/containers are classified from stderr (`apple_stderr_is_not_found`), covered by inline stderr tests.
+
+### 5. Build
+
+Directory builds use:
+
+```sh
+container build -t <reference> <context-dir>
+```
+
+The target release rejects `-` (stdin) as a context directory, so inline instruction builds use a temporary-context fallback: ociman writes the instructions to a temporary `Dockerfile`, builds that directory, and deletes it after the command completes.
+
+### 6. Port publishing
+
+Apple rejects empty host-port auto-assignment syntax (`127.0.0.1::5432`). When `ociman::Publish` allows "any host port", the Apple backend allocates a concrete loopback port itself (`Publish::apple_argument`): it binds a socket to port 0, reads back the assigned ephemeral port, releases it, and passes an explicit `ip:port:containerPort/proto` spec to `container run`. This preserves the ociman API contract. An explicit user-supplied host port is passed through unchanged.
+
+There is a race between allocating the port and `container run` binding it — the port is free when ociman picks it but could be taken by the time the container starts. This is currently **not** retried; a lost race surfaces as a normal bind failure.
+
+Dedicated container IPs via vmnet do not by themselves satisfy ociman's published-host-port API through the released CLI, so the CLI port-publishing behavior is kept explicit and tested.
+
+### 7. Network subnets
+
+On macOS 26, `bridge_subnets()` runs:
+
+```sh
+container network inspect default
+```
+
+and parses the JSON into `Vec<ipnet::IpNet>`, failing explicitly if the command is unavailable or the default network is absent.
+
+## Integration Testing
+
+The Apple acceptance suite is the existing integration corpus run under `OCIMAN_BACKEND=apple`:
+
+```sh
+OCIMAN_BACKEND=apple cargo nextest run --test integration --features test-utils
+```
+
+Apple integration requires macOS 26, Apple `container`, and a running `container system`. `test_backend_setup!()` stays the single entry point; tests that branch on backend match the resolved backend, not the env var.
+
+The existing macOS Actions skip (`platform::support()`) is Docker-specific: it returns `Ok(())` when `OCIMAN_BACKEND=apple`, so an Apple job attempts resolution rather than silently skipping.
+
+Apple integration CI runs on a local self-hosted GitHub runner labeled `aarch64-darwin` so Apple Container can use real local macOS virtualization. Hosted macOS runners already run in VMs and do not allow Apple Container to run containers in their own isolated VMs. Tests run serially to reduce VM/runtime flakiness.
+
+## Known Risks
+
+### Inspect schema drift
+
+Apple inspect JSON is not Docker-shaped and may evolve. Typed parser tests should use fixtures from the supported release.
+
+### List semantics
+
+Apple `container list --format` accepts output format names. Any internal API that accepts template strings is a Docker/Podman-specific seam and should not be reused for Apple.
+
+### Label filtering
+
+Apple `container list` documentation does not advertise `--filter label=...`. Client-side filtering is required unless this becomes supported.
+
+### Missing image classification
+
+`container image inspect <ref>` missing-image stderr may not match Docker/Podman. Add explicit tests for the target release.
+
+### Mount semantics
+
+Bind mounts use virtiofs. Directory mounts are natural; single-file mounts share the file's parent dir into the VM, then bind-mount the file — so sibling files are visible in the VM-level holding mount. Not Docker's isolation boundary: test the public mount behavior, don't promise stronger isolation.
+
+### Build compatibility
+
+Known open Apple Container issues where build behavior does not fully match Docker (beyond the stdin-context fallback in "Build"):
+
+- apple/container#1766 — default build args in `FROM` may not resolve like Docker/Podman.
+- apple/container#1800 — `.dockerignore` resolution differs from Docker.
+- apple/container#1825 — BuildKit may require Rosetta even for arm64 builds.
+
+Keep build tests narrow and document backend-specific behavior.
+
+### Registry behavior
+
+Known open Apple Container registry/auth issues:
+
+- apple/container#1707 — ECR push can fail on manifest PUT with 401.
+- apple/container#1733 — private registry keychain query failure.
+
+Pull/push surface errors as-is (no over-normalizing). Loopback refs (`localhost:5001/...`) pass `--scheme http` so pg-ephemeral can use a throwaway plain-HTTP registry.
+
+### Runtime reliability / test flakiness
+
+Relevant open Apple Container issues:
+
+- apple/container#1876 — foreground TTY/signal hang.
+- apple/container#1747 — SIGWINCH forwarding errors.
+- apple/container#1722 — containers running while `container list` reports empty.
+- apple/container#1873 — `container cp` hangs with mounted volumes.
+- apple/container#1875 — storage/snapshot bloat affecting backups.
+- apple/container#1767 — rootfs journaling concern after ungraceful termination.
+
+These do not block the backend but argue for serial tests and aggressive cleanup.
+
+## Commit emulation
+
+`pg-ephemeral` cache population requires commit before Apple ships built-in
+`container commit`, so ociman implements a limited, Apple-specific
+export-and-build emulation. The Containerization framework makes this
+workable because it includes EXT4 export, archive writing, OCI
+image/config, and content-store APIs.
+
+The emulation:
+
+1. inspects the container and original image,
+2. exports the container filesystem,
+3. generates a temporary build context,
+4. builds a new image from `scratch` with the exported rootfs (using `container build --no-cache` to bound builder cache growth across repeated commits),
+5. reconstructs only the OCI image config fields required by `pg-ephemeral`.
+
+It is limited to the semantics it claims to preserve: environment
+variables, entrypoint/command, workdir, user, labels used by
+ociman/pg-ephemeral, and filesystem contents/ownership relevant to
+PostgreSQL data directories.
+
+When apple/container#1762 (`add commit command`) ships in a release,
+revisit whether to replace the emulation with built-in `container commit`.
+
+## `pg-ephemeral` Cache Shape
+
+On Apple, `pg-ephemeral` uses one committed PostgreSQL cache layer, then
+runs later seeds live, keeping cache chains shallow while built-in commit
+is unavailable.

--- a/ociman/APPLE_BACKEND.md
+++ b/ociman/APPLE_BACKEND.md
@@ -289,22 +289,28 @@ image/config, and content-store APIs.
 
 The emulation:
 
-1. inspects the container and original image,
+1. inspects the container and source image,
 2. exports the container filesystem,
 3. generates a temporary build context,
-4. builds a new image from `scratch` with the exported rootfs (using `container build --no-cache` to bound builder cache growth across repeated commits),
+4. builds a new full-snapshot image from `scratch` with the exported rootfs (using `container build --no-cache` to bound builder cache growth across repeated commits),
 5. reconstructs only the OCI image config fields required by `pg-ephemeral`.
 
-It is limited to the semantics it claims to preserve: environment
-variables, entrypoint/command, workdir, user, labels used by
-ociman/pg-ephemeral, and filesystem contents/ownership relevant to
-PostgreSQL data directories.
+Each Apple commit is a standalone filesystem snapshot rather than a diff
+layer. This is storage-heavy, but it supports repeated cache/seed commits
+without lower-layer resurrection when files are deleted between commits.
+
+It is limited to the semantics it claims to preserve: source-image
+environment variables, entrypoint/command, workdir, user, source-image
+labels, container labels used by ociman/pg-ephemeral, and filesystem
+contents/ownership relevant to PostgreSQL data directories. Container
+labels override source-image labels on key conflict.
 
 When apple/container#1762 (`add commit command`) ships in a release,
 revisit whether to replace the emulation with built-in `container commit`.
 
 ## `pg-ephemeral` Cache Shape
 
-On Apple, `pg-ephemeral` uses one committed PostgreSQL cache layer, then
-runs later seeds live, keeping cache chains shallow while built-in commit
-is unavailable.
+On Apple, `pg-ephemeral` can use repeated committed cache/seed snapshots.
+Each commit exports the full container filesystem and builds a standalone
+`scratch`-based image, trading storage efficiency for predictable cache
+semantics while built-in commit is unavailable.

--- a/ociman/Cargo.toml
+++ b/ociman/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true
-description = "Unified API for OCI container runtimes (Docker, Podman)"
+description = "Unified API for OCI container runtimes (Docker, Podman, Apple Container)"
 license = "MIT"
 repository = "https://github.com/mbj/mrs/tree/main/ociman"
 readme = "README.md"
-keywords = ["docker", "podman", "container", "oci"]
+keywords = ["docker", "podman", "apple", "container", "oci"]
 categories = ["development-tools"]
 
 [features]

--- a/ociman/README.md
+++ b/ociman/README.md
@@ -1,13 +1,13 @@
 # ociman - OCI Manager
 
-A Rust library providing a unified API for OCI container runtimes (Docker, Podman).
+A Rust library providing a unified API for OCI container runtimes (Docker, Podman, Apple Container).
 
 > **Status**: Pre-1.0 - exists to serve [mbj/mrs](https://github.com/mbj/mrs) monorepo, expect breaking changes without notice.
 
 ## Goals
 
 - **Unified API**: Single interface for OCI-compliant container runtimes
-- **Auto-detection**: Automatically detects available container runtime (tries Docker first, then Podman)
+- **Auto-detection**: Automatically detects available container runtime (tries Docker first, then Podman, then Apple Container on macOS)
 - **Configuration file**: Override default backend preference via `~/.config/ociman.toml`
 - **Environment override**: Control backend selection via `OCIMAN_BACKEND` environment variable
 - **Container lifecycle management**: Run, execute commands, inspect, and manage containers
@@ -18,14 +18,22 @@ A Rust library providing a unified API for OCI container runtimes (Docker, Podma
 
 ociman resolves the container backend using this priority chain:
 
-1. `OCIMAN_BACKEND` environment variable (`docker` or `podman`) — explicit selection, errors if not found
+1. `OCIMAN_BACKEND` environment variable (`docker`, `podman`, or `apple`) — explicit selection, errors if not found
 2. `~/.config/ociman.toml` — controls auto-detection preference
-3. Default — tries Docker first, falls back to Podman
+3. Default — tries Docker first, falls back to Podman, then Apple Container on macOS
 
 ```toml
 # ~/.config/ociman.toml
-default_backend = "podman" # or "docker"
+default_backend = "podman" # or "docker", "apple", or "auto"
 ```
+
+Apple Container support targets macOS 26+ with a host-installed `container`
+CLI and a running Apple container system (`container system start`). Apple is
+a first-class backend, not a Docker CLI compatibility layer; unsupported
+features such as inspect-format return explicit errors. Commit is supported via
+an Apple-specific export-and-build fallback because the released Apple CLI does
+not yet ship native commit. Host reachability from Apple containers uses the
+default network gateway reported by `container network inspect default`.
 
 ## Executing Commands in Containers
 
@@ -78,7 +86,7 @@ intentionally does **not** implement `Drop` for automatic cleanup. This is a del
 design decision:
 
 - **Blocking I/O in Drop is unsafe**: Stopping/removing a container shells out to
-  `docker`/`podman`. If the subprocess fails, an `unwrap()` inside Drop causes a panic,
+  `docker`/`podman`/`container`. If the subprocess fails, an `unwrap()` inside Drop causes a panic,
   which aborts the process when unwinding from another panic.
 - **`--rm` is the correct cleanup mechanism**: Use `.remove()` on the `Definition` to pass
   `--rm` to the container runtime. This ensures the runtime removes the container when it

--- a/ociman/src/backend.rs
+++ b/ociman/src/backend.rs
@@ -228,7 +228,6 @@ impl Selection {
     }
 }
 
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Backend {
     Docker {
@@ -485,8 +484,7 @@ impl Backend {
     )]
     pub async fn pull_image(&self, reference: &crate::image::Reference) -> Result<(), PullError> {
         let output = self
-            .command()
-            .arguments(["image", "pull", &reference.to_string()])
+            .image_registry_command("pull", reference)
             .stderr_capture()
             .accept_nonzero_exit()
             .run()
@@ -532,8 +530,7 @@ impl Backend {
     )]
     pub async fn push_image(&self, reference: &crate::image::Reference) -> Result<(), PushError> {
         let output = self
-            .command()
-            .arguments(["image", "push", &reference.to_string()])
+            .image_registry_command("push", reference)
             .stderr_capture()
             .accept_nonzero_exit()
             .run()
@@ -544,6 +541,20 @@ impl Backend {
             })?;
 
         classify_push_result(reference, output.status.success(), &output.bytes)
+    }
+
+    fn image_registry_command(
+        &self,
+        subcommand: &str,
+        reference: &crate::image::Reference,
+    ) -> Command {
+        let command = self.command().arguments(["image", subcommand]);
+        let command = if matches!(self, Self::Apple { .. }) && reference_uses_loopback(reference) {
+            command.arguments(["--scheme", "http"])
+        } else {
+            command
+        };
+        command.argument(reference.to_string())
     }
 
     pub async fn remove_image(&self, reference: &crate::image::Reference) {
@@ -1239,6 +1250,18 @@ fn apple_record_matches_filters(
     })
 }
 
+fn reference_uses_loopback(reference: &crate::image::Reference) -> bool {
+    let Some(domain) = &reference.name.domain else {
+        return false;
+    };
+
+    match &domain.host {
+        crate::reference::Host::DomainName(name) => name.to_string() == "localhost",
+        crate::reference::Host::Ipv4(address) => address.is_loopback(),
+        crate::reference::Host::Ipv6(address) => address.is_loopback(),
+    }
+}
+
 fn apple_host_gateway_from_network_json(value: &serde_json::Value) -> Option<std::net::IpAddr> {
     let values = match value {
         serde_json::Value::Array(values) => values.as_slice(),
@@ -1874,7 +1897,6 @@ mod tests {
         assert!(matches!(result, Err(PullError::Other { .. })));
     }
 
-
     #[test]
     fn test_selection_deserializes_apple() {
         #[derive(serde::Deserialize)]
@@ -1884,6 +1906,23 @@ mod tests {
 
         let example: Example = toml::from_str("default_backend = \"apple\"").unwrap();
         assert_eq!(example.default_backend, Selection::Apple);
+    }
+
+    #[test]
+    fn test_loopback_reference_detection() {
+        assert!(reference_uses_loopback(
+            &"localhost:5001/ociman/alpine:latest".parse().unwrap()
+        ));
+        assert!(reference_uses_loopback(
+            &"127.0.0.1:5001/ociman/alpine:latest".parse().unwrap()
+        ));
+        assert!(reference_uses_loopback(
+            &"[::1]:5001/ociman/alpine:latest".parse().unwrap()
+        ));
+        assert!(!reference_uses_loopback(
+            &"registry.example.com/ociman/alpine:latest".parse().unwrap()
+        ));
+        assert!(!reference_uses_loopback(&"alpine:latest".parse().unwrap()));
     }
 
     #[test]

--- a/ociman/src/backend.rs
+++ b/ociman/src/backend.rs
@@ -1,5 +1,55 @@
 use cmd_proc::*;
 
+pub(crate) fn apple_build_lock() -> AppleBuildLock {
+    AppleBuildLock::acquire()
+}
+
+pub(crate) struct AppleBuildLock {
+    path: std::path::PathBuf,
+    _file: std::fs::File,
+}
+
+impl AppleBuildLock {
+    fn acquire() -> Self {
+        let path = std::env::temp_dir().join("ociman-apple-build.lock");
+        loop {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(file) => return Self { path, _file: file },
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    remove_stale_apple_build_lock(&path);
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                Err(error) => panic!("failed to acquire Apple build lock: {error}"),
+            }
+        }
+    }
+}
+
+impl Drop for AppleBuildLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn remove_stale_apple_build_lock(path: &std::path::Path) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    let Ok(modified) = metadata.modified() else {
+        return;
+    };
+    let Ok(age) = modified.elapsed() else {
+        return;
+    };
+    if age > std::time::Duration::from_secs(600) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
 /// Substring used to detect the OCI distribution-spec `MANIFEST_UNKNOWN`
 /// error code as rendered on stderr by docker, podman, and skopeo when a
 /// registry reports that a tag does not exist.
@@ -532,27 +582,46 @@ impl Backend {
         &self,
         name: &crate::reference::Name,
     ) -> std::collections::BTreeSet<crate::image::Reference> {
-        let output = self
-            .command()
-            .arguments([
-                "image",
-                "list",
-                "--format",
-                "{{.Repository}}:{{.Tag}}",
-                "--filter",
-                &format!("reference={name}:*"),
-            ])
-            .stdout_capture()
-            .string()
-            .await
-            .unwrap();
+        match self {
+            Self::Docker { .. } | Self::Podman { .. } => {
+                let output = self
+                    .command()
+                    .arguments([
+                        "image",
+                        "list",
+                        "--format",
+                        "{{.Repository}}:{{.Tag}}",
+                        "--filter",
+                        &format!("reference={name}:*"),
+                    ])
+                    .stdout_capture()
+                    .string()
+                    .await
+                    .unwrap();
 
-        output
-            .lines()
-            .filter(|line| !line.is_empty())
-            .map(|line| line.parse::<crate::image::Reference>().unwrap())
-            .filter(|reference| reference.name.path == name.path)
-            .collect()
+                output
+                    .lines()
+                    .filter(|line| !line.is_empty())
+                    .map(|line| line.parse::<crate::image::Reference>().unwrap())
+                    .filter(|reference| reference.name.path == name.path)
+                    .collect()
+            }
+            Self::Apple { .. } => {
+                let output = self
+                    .command()
+                    .arguments(["image", "list", "--format", "json"])
+                    .stdout_capture()
+                    .string()
+                    .await
+                    .unwrap();
+                let value = serde_json::from_str::<serde_json::Value>(&output).unwrap();
+
+                apple_image_references_from_json(&value)
+                    .into_iter()
+                    .filter(|reference| reference.name.path == name.path)
+                    .collect()
+            }
+        }
     }
 
     /// Create a hostname resolver that runs inside a container
@@ -1084,6 +1153,24 @@ struct AppleRecord {
     labels: std::collections::BTreeMap<String, String>,
 }
 
+fn apple_image_references_from_json(value: &serde_json::Value) -> Vec<crate::image::Reference> {
+    let values = match value {
+        serde_json::Value::Array(values) => values.as_slice(),
+        _ => std::slice::from_ref(value),
+    };
+
+    values
+        .iter()
+        .filter_map(|value| {
+            value
+                .pointer("/configuration/name")
+                .or_else(|| value.get("name"))
+                .and_then(serde_json::Value::as_str)
+                .and_then(|reference| reference.parse::<crate::image::Reference>().ok())
+        })
+        .collect()
+}
+
 fn apple_container_records_from_json(
     value: &serde_json::Value,
 ) -> Result<Vec<AppleRecord>, serde_json::Error> {
@@ -1108,12 +1195,16 @@ fn apple_container_records_from_json(
                 .or_else(|| value.pointer("/configuration/id"))
                 .and_then(serde_json::Value::as_str)
                 .map(ToOwned::to_owned);
-            let labels = value
+            let labels: std::collections::BTreeMap<String, String> = value
                 .get("labels")
                 .or_else(|| value.pointer("/configuration/labels"))
                 .map(|labels| serde_json::from_value(labels.clone()))
                 .transpose()?
                 .unwrap_or_default();
+            let labels = labels
+                .into_iter()
+                .map(|(key, value)| (key, crate::label::apple_decode_value(&value)))
+                .collect();
 
             Ok(AppleRecord {
                 id: crate::ContainerId(id),

--- a/ociman/src/backend.rs
+++ b/ociman/src/backend.rs
@@ -153,12 +153,18 @@ fn classify_push_result(
     })
 }
 
+fn apple_stderr_is_not_found(stderr: &[u8]) -> bool {
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    stderr.contains("not found") || stderr.contains("no such")
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum Selection {
     Auto,
     Docker,
     Podman,
+    Apple,
 }
 
 impl Selection {
@@ -167,9 +173,11 @@ impl Selection {
             Self::Auto => resolve::auto().await,
             Self::Docker => resolve::docker().await,
             Self::Podman => resolve::podman().await,
+            Self::Apple => resolve::apple().await,
         }
     }
 }
+
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Backend {
@@ -181,17 +189,22 @@ pub enum Backend {
         version: semver::Version,
         rootless: bool,
     },
+    Apple {
+        version: semver::Version,
+    },
 }
 
 impl Backend {
     const DOCKER_EXECUTABLE: &'static str = "docker";
     const PODMAN_EXECUTABLE: &'static str = "podman";
+    const APPLE_CONTAINER_EXECUTABLE: &'static str = "container";
 
     #[must_use]
     pub fn command(&self) -> Command {
         match self {
             Self::Docker { .. } => Command::new(Self::DOCKER_EXECUTABLE),
             Self::Podman { .. } => Command::new(Self::PODMAN_EXECUTABLE),
+            Self::Apple { .. } => Command::new(Self::APPLE_CONTAINER_EXECUTABLE),
         }
     }
 
@@ -265,6 +278,28 @@ impl Backend {
                     }),
                 }
             }
+            Self::Apple { .. } => {
+                let result = self
+                    .command()
+                    .arguments(["image", "inspect", &reference_string])
+                    .stdout_capture()
+                    .stderr_capture()
+                    .accept_nonzero_exit()
+                    .run()
+                    .await
+                    .map_err(ImagePresentError::Command)?;
+
+                if result.status.success() {
+                    Ok(true)
+                } else if apple_stderr_is_not_found(&result.stderr) {
+                    Ok(false)
+                } else {
+                    Err(ImagePresentError::Subprocess {
+                        exit_status: result.status,
+                        stderr: String::from_utf8_lossy(&result.stderr).into_owned(),
+                    })
+                }
+            }
         }
     }
 
@@ -336,6 +371,28 @@ impl Backend {
                     }),
                 }
             }
+            Self::Apple { .. } => {
+                let result = self
+                    .command()
+                    .arguments(["inspect", id.as_str()])
+                    .stdout_capture()
+                    .stderr_capture()
+                    .accept_nonzero_exit()
+                    .run()
+                    .await
+                    .map_err(ContainerPresentError::Command)?;
+
+                if result.status.success() {
+                    Ok(true)
+                } else if apple_stderr_is_not_found(&result.stderr) {
+                    Ok(false)
+                } else {
+                    Err(ContainerPresentError::Subprocess {
+                        exit_status: result.status,
+                        stderr: String::from_utf8_lossy(&result.stderr).into_owned(),
+                    })
+                }
+            }
         }
     }
 
@@ -350,6 +407,7 @@ impl Backend {
     pub const fn is_rootless(&self) -> bool {
         match self {
             Self::Docker { rootless, .. } | Self::Podman { rootless, .. } => *rootless,
+            Self::Apple { .. } => false,
         }
     }
 
@@ -447,7 +505,10 @@ impl Backend {
     }
 
     async fn do_remove_image(&self, reference: &crate::image::Reference, force: bool) {
-        let command = self.command().arguments(["image", "rm"]);
+        let command = match self {
+            Self::Docker { .. } | Self::Podman { .. } => self.command().arguments(["image", "rm"]),
+            Self::Apple { .. } => self.command().arguments(["image", "delete"]),
+        };
         let command = if force {
             command.argument("--force")
         } else {
@@ -552,6 +613,9 @@ impl Backend {
                     .resolve("host.docker.internal")
                     .await
             }
+            Backend::Apple { .. } => Err(ResolveHostnameError::Unsupported {
+                hint: "Apple Container does not expose a stable Docker-style host hostname; configure host reachability explicitly",
+            }),
         }
     }
 
@@ -570,7 +634,12 @@ impl Backend {
     where
         I: IntoIterator<Item = &'id crate::ContainerId>,
     {
-        let mut command = self.command().arguments(["container", "inspect"]);
+        let mut command = match self {
+            Self::Docker { .. } | Self::Podman { .. } => {
+                self.command().arguments(["container", "inspect"])
+            }
+            Self::Apple { .. } => self.command().argument("inspect"),
+        };
         for id in ids {
             command = command.argument(id);
         }
@@ -597,7 +666,11 @@ impl Backend {
             ));
         }
 
-        Ok(serde_json::from_slice(&result.stdout)?)
+        let value: serde_json::Value = serde_json::from_slice(&result.stdout)?;
+        match value {
+            serde_json::Value::Array(values) => Ok(values),
+            value => Ok(vec![value]),
+        }
     }
 
     /// Run `inspect --format` against a container and return the rendered
@@ -611,6 +684,10 @@ impl Backend {
         id: &crate::ContainerId,
         format: &str,
     ) -> Result<String, crate::InspectError> {
+        if let Self::Apple { .. } = self {
+            return Err(crate::InspectError::FormatUnsupported);
+        }
+
         let result = self
             .command()
             .arguments(["container", "inspect", "--format"])
@@ -670,7 +747,7 @@ impl Backend {
     ) -> Result<crate::ContainerName, crate::ContainerNameError> {
         let normalised = match self {
             Backend::Docker { .. } => raw.strip_prefix('/').unwrap_or(raw),
-            Backend::Podman { .. } => raw,
+            Backend::Podman { .. } | Backend::Apple { .. } => raw,
         };
         normalised.parse()
     }
@@ -688,6 +765,9 @@ impl Backend {
             .unwrap();
         let raw = value
             .get("Name")
+            .or_else(|| value.get("name"))
+            .or_else(|| value.pointer("/configuration/id"))
+            .or_else(|| value.get("id"))
             .and_then(|name_value| name_value.as_str())
             .ok_or(crate::container::ReadContainerNameError::NameNotString)?;
         Ok(self.parse_container_name(raw)?)
@@ -730,10 +810,13 @@ impl Backend {
             ));
         }
 
-        // Single-ref inspect: docker always returns a length-1 array on
-        // success; peel the singleton.
-        let array: Vec<serde_json::Value> = serde_json::from_slice(&result.stdout)?;
-        Ok(array.into_iter().next().unwrap())
+        // Single-ref inspect returns a length-1 array for Docker, Podman, and
+        // Apple Container; peel the singleton.
+        let value: serde_json::Value = serde_json::from_slice(&result.stdout)?;
+        match value {
+            serde_json::Value::Array(values) => Ok(values.into_iter().next().unwrap()),
+            value => Ok(value),
+        }
     }
 
     /// Read the labels on an image by reference.
@@ -758,17 +841,24 @@ impl Backend {
         format: &str,
         label_filters: impl IntoIterator<Item = crate::label::Filter<'a>>,
     ) -> Result<String, ContainerListError> {
-        let mut command = self.command().arguments([
-            "container",
-            "list",
-            "--all",
-            "--no-trunc",
-            "--format",
-            format,
-        ]);
+        let mut command = match self {
+            Self::Docker { .. } | Self::Podman { .. } => self.command().arguments([
+                "container",
+                "list",
+                "--all",
+                "--no-trunc",
+                "--format",
+                format,
+            ]),
+            Self::Apple { .. } => self
+                .command()
+                .arguments(["list", "--all", "--format", format]),
+        };
 
-        for filter in label_filters {
-            command = command.argument("--filter").argument(filter.to_string());
+        if !matches!(self, Self::Apple { .. }) {
+            for filter in label_filters {
+                command = command.argument("--filter").argument(filter.to_string());
+            }
         }
 
         let result = command
@@ -809,6 +899,27 @@ impl Backend {
         &self,
         label_filters: impl IntoIterator<Item = crate::label::Filter<'a>>,
     ) -> Result<Vec<(crate::Container, crate::ContainerName)>, ContainerListWithNameError> {
+        if let Self::Apple { .. } = self {
+            return self
+                .apple_container_records(label_filters)
+                .await?
+                .into_iter()
+                .map(|record| {
+                    let raw_name = record.name.as_deref().unwrap_or(record.id.as_str());
+                    let name = raw_name
+                        .parse()
+                        .map_err(ContainerListWithNameError::InvalidContainerName)?;
+                    Ok((
+                        crate::Container {
+                            backend: self.clone(),
+                            id: record.id,
+                        },
+                        name,
+                    ))
+                })
+                .collect();
+        }
+
         let stdout = self
             .container_list("{{.ID}}\t{{.Names}}", label_filters)
             .await?;
@@ -847,6 +958,18 @@ impl Backend {
             Some(value) => crate::label::Filter::exact(key, value),
         };
 
+        if let Self::Apple { .. } = self {
+            return Ok(self
+                .apple_container_records([filter])
+                .await?
+                .into_iter()
+                .map(|record| crate::Container {
+                    backend: self.clone(),
+                    id: record.id,
+                })
+                .collect());
+        }
+
         let stdout = self.container_list("{{.ID}}", [filter]).await?;
 
         Ok(stdout
@@ -856,6 +979,22 @@ impl Backend {
                 backend: self.clone(),
                 id: crate::ContainerId(id.to_string()),
             })
+            .collect())
+    }
+
+    async fn apple_container_records<'a>(
+        &self,
+        label_filters: impl IntoIterator<Item = crate::label::Filter<'a>>,
+    ) -> Result<Vec<AppleRecord>, ContainerListError> {
+        let filters: Vec<_> = label_filters.into_iter().collect();
+        let stdout = self.container_list("json", []).await?;
+        let value: serde_json::Value =
+            serde_json::from_str(&stdout).map_err(ContainerListError::Json)?;
+        let records =
+            apple_container_records_from_json(&value).map_err(ContainerListError::Json)?;
+        Ok(records
+            .into_iter()
+            .filter(|record| apple_record_matches_filters(record, &filters))
             .collect())
     }
 
@@ -870,6 +1009,7 @@ impl Backend {
             .arguments(match self {
                 Self::Docker { .. } => ["network", "inspect", "bridge"],
                 Self::Podman { .. } => ["network", "inspect", "podman"],
+                Self::Apple { .. } => ["network", "inspect", "default"],
             })
             .stdout_capture()
             .bytes()
@@ -895,6 +1035,14 @@ impl Backend {
                     .into_iter()
                     .flat_map(|n| n.subnets)
                     .map(|s| s.subnet)
+                    .collect())
+            }
+            Self::Apple { .. } => {
+                let value: serde_json::Value =
+                    serde_json::from_slice(&stdout).map_err(BridgeSubnetError::JsonParseFailed)?;
+                Ok(collect_ipnets_from_json(&value)
+                    .into_iter()
+                    .filter(|subnet| matches!(subnet, ipnet::IpNet::V4(_)))
                     .collect())
             }
         }
@@ -927,6 +1075,94 @@ struct PodmanNetworkInspect {
 #[derive(serde::Deserialize)]
 struct PodmanSubnet {
     subnet: ipnet::IpNet,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct AppleRecord {
+    id: crate::ContainerId,
+    name: Option<String>,
+    labels: std::collections::BTreeMap<String, String>,
+}
+
+fn apple_container_records_from_json(
+    value: &serde_json::Value,
+) -> Result<Vec<AppleRecord>, serde_json::Error> {
+    let values = match value {
+        serde_json::Value::Array(values) => values.as_slice(),
+        _ => std::slice::from_ref(value),
+    };
+
+    values
+        .iter()
+        .map(|value| {
+            let id = value
+                .get("id")
+                .or_else(|| value.get("ID"))
+                .or_else(|| value.get("containerID"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let name = value
+                .get("name")
+                .or_else(|| value.get("Name"))
+                .or_else(|| value.pointer("/configuration/id"))
+                .and_then(serde_json::Value::as_str)
+                .map(ToOwned::to_owned);
+            let labels = value
+                .get("labels")
+                .or_else(|| value.pointer("/configuration/labels"))
+                .map(|labels| serde_json::from_value(labels.clone()))
+                .transpose()?
+                .unwrap_or_default();
+
+            Ok(AppleRecord {
+                id: crate::ContainerId(id),
+                name,
+                labels,
+            })
+        })
+        .collect()
+}
+
+fn apple_record_matches_filters(
+    record: &AppleRecord,
+    filters: &[crate::label::Filter<'_>],
+) -> bool {
+    filters.iter().all(|filter| {
+        let Some(value) = record.labels.get(filter.key.as_str()) else {
+            return false;
+        };
+        filter
+            .value
+            .is_none_or(|expected| value == expected.as_str())
+    })
+}
+
+fn collect_ipnets_from_json(value: &serde_json::Value) -> Vec<ipnet::IpNet> {
+    let mut subnets = Vec::new();
+    collect_ipnets_from_json_value(value, &mut subnets);
+    subnets
+}
+
+fn collect_ipnets_from_json_value(value: &serde_json::Value, subnets: &mut Vec<ipnet::IpNet>) {
+    match value {
+        serde_json::Value::String(string) => {
+            if let Ok(subnet) = string.parse::<ipnet::IpNet>() {
+                subnets.push(subnet);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_ipnets_from_json_value(value, subnets);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            for value in object.values() {
+                collect_ipnets_from_json_value(value, subnets);
+            }
+        }
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1003,6 +1239,8 @@ pub enum ContainerListWithNameError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ContainerListError {
+    #[error("`container list` output was not valid JSON")]
+    Json(#[source] serde_json::Error),
     #[error("`container list` command IO failure")]
     Io(#[source] std::io::Error),
     #[error("`container list` exited with {exit_status}: {stderr}")]
@@ -1027,6 +1265,9 @@ pub enum BridgeSubnetError {
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum ResolveHostnameError {
+    #[error("hostname resolution is unsupported on apple: {hint}")]
+    Unsupported { hint: &'static str },
+
     #[error("hostname resolution command failed: {0}")]
     CommandFailed(String),
 
@@ -1148,11 +1389,21 @@ pub mod resolve {
         #[error("Failed to load config")]
         ConfigLoad(#[source] crate::config::Error),
         #[error(
-            "Invalid env variable for {ENV_VARIABLE_NAME}, expected \"podman\" or \"docker\", got: {0}"
+            "Invalid env variable for {ENV_VARIABLE_NAME}, expected \"podman\", \"docker\", or \"apple\", got: {0}"
         )]
         InvalidEnvVariable(String),
-        #[error("No container tool detected in $PATH, searched for podman and docker")]
+        #[error("No container tool detected in $PATH, searched for docker, podman, and apple")]
         NoContainerToolDetected,
+        #[error("Apple Container backend is only supported on macOS")]
+        AppleUnsupportedPlatform,
+        #[error("Apple Container backend requires macOS 26 or newer, found {version}")]
+        AppleUnsupportedMacOsVersion { version: String },
+        #[error("Failed to detect macOS version: {message}")]
+        MacOsVersionDetectionFailed { message: String },
+        #[error(
+            "Apple Container system is not running: {status}. Start it with `container system start`"
+        )]
+        AppleSystemNotRunning { status: String },
         #[error("Failed to detect {executable} version: {message}")]
         VersionDetectionFailed {
             executable: &'static str,
@@ -1212,10 +1463,19 @@ pub mod resolve {
         Ok(Backend::Podman { version, rootless })
     }
 
+    /// Resolve Apple Container backend with version and readiness detection.
+    pub async fn apple() -> Result {
+        ensure_apple_supported_platform().await?;
+        let version = detect_version(Backend::APPLE_CONTAINER_EXECUTABLE).await?;
+        ensure_apple_system_running().await?;
+        Ok(Backend::Apple { version })
+    }
+
     async fn from_env_value(value: &str) -> Result {
         match value {
             "docker" => docker().await,
             "podman" => podman().await,
+            "apple" => apple().await,
             _ => Err(Error::InvalidEnvVariable(value.to_string())),
         }
     }
@@ -1226,11 +1486,102 @@ pub mod resolve {
                 Ok(backend) => Ok(backend),
                 Err(_) => docker().await.map_err(|_| Error::NoContainerToolDetected),
             },
-            super::Selection::Docker | super::Selection::Auto => match docker().await {
+            super::Selection::Docker => match docker().await {
                 Ok(backend) => Ok(backend),
                 Err(_) => podman().await.map_err(|_| Error::NoContainerToolDetected),
             },
+            super::Selection::Apple => match apple().await {
+                Ok(backend) => Ok(backend),
+                Err(_) => match docker().await {
+                    Ok(backend) => Ok(backend),
+                    Err(_) => podman().await.map_err(|_| Error::NoContainerToolDetected),
+                },
+            },
+            super::Selection::Auto => match docker().await {
+                Ok(backend) => Ok(backend),
+                Err(_) => match podman().await {
+                    Ok(backend) => Ok(backend),
+                    Err(_) => apple().await.map_err(|_| Error::NoContainerToolDetected),
+                },
+            },
         }
+    }
+
+    async fn ensure_apple_supported_platform() -> std::result::Result<(), Error> {
+        #[cfg(not(target_os = "macos"))]
+        {
+            Err(Error::AppleUnsupportedPlatform)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let version = detect_macos_version().await?;
+            let major = version
+                .split('.')
+                .next()
+                .and_then(|major| major.parse::<u64>().ok())
+                .ok_or_else(|| Error::MacOsVersionDetectionFailed {
+                    message: format!("could not parse macOS version {version:?}"),
+                })?;
+
+            if major >= 26 {
+                Ok(())
+            } else {
+                Err(Error::AppleUnsupportedMacOsVersion { version })
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn detect_macos_version() -> std::result::Result<String, Error> {
+        let output = Command::new("sw_vers")
+            .argument("-productVersion")
+            .stdout_capture()
+            .bytes()
+            .await
+            .map_err(|error| Error::MacOsVersionDetectionFailed {
+                message: error.to_string(),
+            })?;
+
+        let version =
+            std::str::from_utf8(&output).map_err(|_| Error::MacOsVersionDetectionFailed {
+                message: "invalid UTF-8 in sw_vers output".to_string(),
+            })?;
+        Ok(version.trim().to_string())
+    }
+
+    async fn ensure_apple_system_running() -> std::result::Result<(), Error> {
+        let output = Command::new(Backend::APPLE_CONTAINER_EXECUTABLE)
+            .arguments(["system", "status", "--format", "json"])
+            .stdout_capture()
+            .bytes()
+            .await
+            .map_err(|error| Error::VersionDetectionFailed {
+                executable: Backend::APPLE_CONTAINER_EXECUTABLE,
+                message: error.to_string(),
+            })?;
+
+        let status: serde_json::Value =
+            serde_json::from_slice(&output).map_err(|error| Error::VersionDetectionFailed {
+                executable: Backend::APPLE_CONTAINER_EXECUTABLE,
+                message: format!("invalid system status JSON: {error}"),
+            })?;
+
+        if apple_system_status_is_running(&status) {
+            Ok(())
+        } else {
+            Err(Error::AppleSystemNotRunning {
+                status: status.to_string(),
+            })
+        }
+    }
+
+    pub(super) fn apple_system_status_is_running(status: &serde_json::Value) -> bool {
+        status
+            .get("status")
+            .or_else(|| status.get("state"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|status| status.eq_ignore_ascii_case("running"))
     }
 
     async fn detect_version(
@@ -1318,6 +1669,7 @@ pub mod resolve {
         // Extract version string from output like:
         // Docker: "Docker version 29.0.0, build abcdef1"
         // Podman: "podman version 4.9.0"
+        // Apple: "container version 1.0.0"
         let version_str = output
             .split_whitespace()
             .find(|word| word.chars().next().is_some_and(|c| c.is_ascii_digit()))
@@ -1398,6 +1750,97 @@ mod tests {
         let stderr = b"Error response from daemon: Get https://ghcr.io/v2/: dial tcp: lookup ghcr.io: no such host";
         let result = classify_pull_result(&reference, false, stderr);
         assert!(matches!(result, Err(PullError::Other { .. })));
+    }
+
+
+    #[test]
+    fn test_selection_deserializes_apple() {
+        #[derive(serde::Deserialize)]
+        struct Example {
+            default_backend: Selection,
+        }
+
+        let example: Example = toml::from_str("default_backend = \"apple\"").unwrap();
+        assert_eq!(example.default_backend, Selection::Apple);
+    }
+
+    #[test]
+    fn test_apple_system_status_accepts_running_status() {
+        let status = serde_json::json!({ "status": "running" });
+        assert!(resolve::apple_system_status_is_running(&status));
+    }
+
+    #[test]
+    fn test_apple_system_status_rejects_stopped_status() {
+        let status = serde_json::json!({ "status": "stopped" });
+        assert!(!resolve::apple_system_status_is_running(&status));
+    }
+
+    #[test]
+    fn test_apple_container_records_parse_labels_from_configuration() {
+        let json = serde_json::json!([{
+            "id": "ociman-test",
+            "name": "ociman-test",
+            "configuration": {
+                "labels": {
+                    "com.example.role": "database"
+                }
+            }
+        }]);
+
+        let records = apple_container_records_from_json(&json).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].id.as_str(), "ociman-test");
+        assert_eq!(records[0].name.as_deref(), Some("ociman-test"));
+        assert_eq!(
+            records[0]
+                .labels
+                .get("com.example.role")
+                .map(String::as_str),
+            Some("database")
+        );
+    }
+
+    #[test]
+    fn test_apple_record_matches_key_only_and_exact_label_filters() {
+        let key: crate::label::Key = "com.example.role".parse().unwrap();
+        let value: crate::label::Value = "database".parse().unwrap();
+        let other: crate::label::Value = "cache".parse().unwrap();
+        let record = AppleRecord {
+            id: crate::ContainerId("ociman-test".to_string()),
+            name: None,
+            labels: std::collections::BTreeMap::from([(
+                "com.example.role".to_string(),
+                "database".to_string(),
+            )]),
+        };
+
+        assert!(apple_record_matches_filters(
+            &record,
+            &[crate::label::Filter::key_only(&key)]
+        ));
+        assert!(apple_record_matches_filters(
+            &record,
+            &[crate::label::Filter::exact(&key, &value)]
+        ));
+        assert!(!apple_record_matches_filters(
+            &record,
+            &[crate::label::Filter::exact(&key, &other)]
+        ));
+    }
+
+    #[test]
+    fn test_collect_ipnets_from_apple_network_json() {
+        let json = serde_json::json!({
+            "name": "default",
+            "subnet": "192.168.64.0/24",
+            "gateway": "192.168.64.1"
+        });
+
+        assert_eq!(
+            collect_ipnets_from_json(&json),
+            vec!["192.168.64.0/24".parse::<ipnet::IpNet>().unwrap()]
+        );
     }
 
     #[test]

--- a/ociman/src/backend.rs
+++ b/ociman/src/backend.rs
@@ -682,9 +682,19 @@ impl Backend {
                     .resolve("host.docker.internal")
                     .await
             }
-            Backend::Apple { .. } => Err(ResolveHostnameError::Unsupported {
-                hint: "Apple Container does not expose a stable Docker-style host hostname; configure host reachability explicitly",
-            }),
+            Backend::Apple { .. } => {
+                let output = self
+                    .command()
+                    .arguments(["network", "inspect", "default"])
+                    .stdout_capture()
+                    .string()
+                    .await
+                    .map_err(|error| ResolveHostnameError::CommandFailed(error.to_string()))?;
+                let value: serde_json::Value = serde_json::from_str(&output)
+                    .map_err(|error| ResolveHostnameError::JsonParseFailed(error.to_string()))?;
+                apple_host_gateway_from_network_json(&value)
+                    .ok_or(ResolveHostnameError::MissingAppleGateway)
+            }
         }
     }
 
@@ -1229,6 +1239,20 @@ fn apple_record_matches_filters(
     })
 }
 
+fn apple_host_gateway_from_network_json(value: &serde_json::Value) -> Option<std::net::IpAddr> {
+    let values = match value {
+        serde_json::Value::Array(values) => values.as_slice(),
+        _ => std::slice::from_ref(value),
+    };
+
+    values.iter().find_map(|value| {
+        value
+            .pointer("/status/ipv4Gateway")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|gateway| gateway.parse::<std::net::IpAddr>().ok())
+    })
+}
+
 fn collect_ipnets_from_json(value: &serde_json::Value) -> Vec<ipnet::IpNet> {
     let mut subnets = Vec::new();
     collect_ipnets_from_json_value(value, &mut subnets);
@@ -1356,11 +1380,14 @@ pub enum BridgeSubnetError {
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum ResolveHostnameError {
-    #[error("hostname resolution is unsupported on apple: {hint}")]
-    Unsupported { hint: &'static str },
-
     #[error("hostname resolution command failed: {0}")]
     CommandFailed(String),
+
+    #[error("failed to parse network inspect JSON: {0}")]
+    JsonParseFailed(String),
+
+    #[error("Apple network inspect output did not include status.ipv4Gateway")]
+    MissingAppleGateway,
 
     #[error("Invalid UTF-8 in resolution output")]
     InvalidUtf8,
@@ -1433,10 +1460,14 @@ impl ContainerHostnameResolver {
     pub async fn resolve(self, hostname: &str) -> Result<std::net::IpAddr, ResolveHostnameError> {
         const ALPINE_IMAGE: &str = "alpine:latest";
 
-        let output = self
-            .backend
-            .command()
-            .arguments(["container", "run"])
+        let command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => {
+                self.backend.command().arguments(["container", "run"])
+            }
+            Backend::Apple { .. } => self.backend.command().argument("run"),
+        };
+
+        let output = command
             .argument("--rm")
             .arguments(&self.container_arguments)
             .argument(ALPINE_IMAGE)
@@ -1935,6 +1966,22 @@ mod tests {
     }
 
     #[test]
+    fn test_apple_host_gateway_from_network_json() {
+        let json = serde_json::json!([{
+            "id": "default",
+            "status": {
+                "ipv4Gateway": "192.168.65.1",
+                "ipv4Subnet": "192.168.65.0/24"
+            }
+        }]);
+
+        assert_eq!(
+            apple_host_gateway_from_network_json(&json),
+            Some("192.168.65.1".parse().unwrap())
+        );
+    }
+
+    #[test]
     fn test_classify_push_result_success() {
         let reference = pull_test_reference();
         assert!(classify_push_result(&reference, true, b"").is_ok());
@@ -1972,6 +2019,9 @@ mod tests {
     #[tokio::test]
     async fn test_container_resolver_with_add_host() {
         let backend = crate::test_backend_setup!();
+        if matches!(backend, Backend::Apple { .. }) {
+            return;
+        }
 
         let ip = backend
             .container_resolver()
@@ -2005,6 +2055,9 @@ mod tests {
     #[tokio::test]
     async fn test_container_resolver_with_multiple_arguments() {
         let backend = crate::test_backend_setup!();
+        if matches!(backend, Backend::Apple { .. }) {
+            return;
+        }
 
         let ip = backend
             .container_resolver()
@@ -2022,6 +2075,9 @@ mod tests {
     #[tokio::test]
     async fn test_container_resolver_builder_pattern() {
         let backend = crate::test_backend_setup!();
+        if matches!(backend, Backend::Apple { .. }) {
+            return;
+        }
 
         let resolver = backend
             .container_resolver()

--- a/ociman/src/backend.rs
+++ b/ociman/src/backend.rs
@@ -29,8 +29,8 @@ impl AppleBuildLock {
     }
 }
 
-impl Drop for AppleBuildLock {
-    fn drop(&mut self) {
+impl AppleBuildLock {
+    pub(crate) fn release(self) {
         let _ = std::fs::remove_file(&self.path);
     }
 }

--- a/ociman/src/container.rs
+++ b/ociman/src/container.rs
@@ -289,6 +289,24 @@ pub struct Publish {
 }
 
 impl Publish {
+    fn apple_argument(&self) -> Result<String, RunError> {
+        let host_binding = self.host_binding.unwrap_or(HostBinding {
+            ip: UNSPECIFIED_IP,
+            port: None,
+        });
+        let host_port = match host_binding.port {
+            Some(port) => port,
+            None => allocate_host_port(host_binding.ip, self.protocol)?,
+        };
+        Ok(format!(
+            "{}:{}:{}/{}",
+            host_binding.ip,
+            host_port,
+            self.container_port,
+            self.protocol.as_str()
+        ))
+    }
+
     /// Creates a TCP port publish configuration.
     ///
     /// # Example
@@ -440,6 +458,19 @@ impl std::fmt::Display for Publish {
 impl Apply for Publish {
     fn apply(&self, command: Command) -> Command {
         command.argument("--publish").argument(self.to_string())
+    }
+}
+
+fn allocate_host_port(ip: std::net::IpAddr, protocol: Protocol) -> Result<u16, RunError> {
+    match protocol {
+        Protocol::Tcp => std::net::TcpListener::bind((ip, 0))
+            .and_then(|listener| listener.local_addr())
+            .map(|address| address.port())
+            .map_err(RunError::Io),
+        Protocol::Udp => std::net::UdpSocket::bind((ip, 0))
+            .and_then(|socket| socket.local_addr())
+            .map(|address| address.port())
+            .map_err(RunError::Io),
     }
 }
 
@@ -742,7 +773,7 @@ impl Definition {
         let result = self
             .clone()
             .detach()
-            .to_cmd_proc_command()
+            .to_cmd_proc_command()?
             .stdout_capture()
             .stderr_capture()
             .accept_nonzero_exit()
@@ -767,6 +798,15 @@ impl Definition {
         self.clone()
             .no_detach()
             .to_cmd_proc_command()
+            .map_err(|error| match error {
+                RunError::Io(io) => CommandError::Io(io),
+                RunError::Subprocess { exit_status, .. } => CommandError::ExitStatus(exit_status),
+                RunError::NameInUse { .. }
+                | RunError::StderrUtf8(_)
+                | RunError::UnsupportedOption { .. } => {
+                    CommandError::Io(std::io::Error::other(error))
+                }
+            })?
             .stdout_capture()
             .bytes()
             .await
@@ -776,7 +816,7 @@ impl Definition {
     /// classified [`RunError`].
     pub async fn run(&self) -> Result<(), RunError> {
         let result = self
-            .to_cmd_proc_command()
+            .to_cmd_proc_command()?
             .stdout_capture()
             .stderr_capture()
             .accept_nonzero_exit()
@@ -807,7 +847,7 @@ impl Definition {
         // when a name was actually configured; otherwise a collision is
         // impossible and any match would be spurious.
         if let Some(name) = &self.name
-            && stderr.contains("is already in use")
+            && (stderr.contains("is already in use") || stderr.contains("already exists"))
         {
             return RunError::NameInUse { name: name.clone() };
         }
@@ -825,25 +865,46 @@ impl Definition {
     /// (`.status()`, `.stdout_capture().bytes()`, …) rather than picking a
     /// pre-baked run method. Symmetric with
     /// [`ExecCommand::to_cmd_proc_command`].
-    #[must_use]
-    pub fn to_cmd_proc_command(&self) -> Command {
-        let command = self.backend.command().arguments(["container", "run"]);
+    pub fn to_cmd_proc_command(&self) -> Result<Command, RunError> {
+        let command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => {
+                self.backend.command().arguments(["container", "run"])
+            }
+            Backend::Apple { .. } => self.backend.command().argument("run"),
+        };
 
         let command = self.detach.apply(command);
         let command = self.remove.apply(command);
         let command = self.tty.apply(command);
         let command = self.interactive.apply(command);
-        let command = self.pull_policy.apply(command);
+        let command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => self.pull_policy.apply(command),
+            Backend::Apple { .. } if self.pull_policy.is_some() => {
+                return Err(RunError::UnsupportedOption {
+                    option: "pull_policy",
+                });
+            }
+            Backend::Apple { .. } => command,
+        };
         let command = self.name.apply(command);
         let command = self.environment_variables.apply(command);
         let command = self.labels.apply(command);
-        let command = self.publish.apply(command);
+        let command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => self.publish.apply(command),
+            Backend::Apple { .. } => {
+                self.publish.iter().try_fold(command, |command, publish| {
+                    Ok(command
+                        .argument("--publish")
+                        .argument(publish.apple_argument()?))
+                })?
+            }
+        };
         let command = self.mounts.apply(command);
         let command = self.workdir.apply(command);
         let command = self.entrypoint.apply(command);
         let command = self.reference.apply(command);
 
-        self.container_arguments.apply(command)
+        Ok(self.container_arguments.apply(command))
     }
 }
 
@@ -892,6 +953,9 @@ pub struct Container {
 
 #[derive(Debug, thiserror::Error)]
 pub enum InspectError {
+    #[error("inspect format is unsupported on apple")]
+    FormatUnsupported,
+
     /// At least one inspect target is absent.
     ///
     /// Detected by matching the runtime's stderr against `no such ` (case
@@ -938,7 +1002,8 @@ impl InspectError {
             Err(source) => return Self::Utf8(source),
         };
         let lower = stderr.to_ascii_lowercase();
-        if lower.contains("no such ") || lower.contains("not known") {
+        if lower.contains("no such ") || lower.contains("not known") || lower.contains("not found")
+        {
             return Self::NotFound;
         }
         Self::Subprocess {
@@ -946,6 +1011,14 @@ impl InspectError {
             stderr: stderr.to_owned(),
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommitError {
+    #[error("commit is unsupported on apple")]
+    Unsupported,
+    #[error(transparent)]
+    Command(#[from] CommandError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -972,10 +1045,68 @@ pub enum ReadHostTcpPortError {
     },
 }
 
+fn read_apple_host_tcp_port(
+    value: &serde_json::Value,
+    container_port: u16,
+) -> Result<u16, ReadHostTcpPortError> {
+    let published_ports = value
+        .pointer("/configuration/publishedPorts")
+        .and_then(serde_json::Value::as_array)
+        .ok_or(ReadHostTcpPortError::NotPublished { container_port })?;
+
+    for published_port in published_ports {
+        let is_tcp = published_port
+            .get("proto")
+            .or_else(|| published_port.get("protocol"))
+            .and_then(serde_json::Value::as_str)
+            .is_none_or(|protocol| protocol.eq_ignore_ascii_case("tcp"));
+        if !is_tcp {
+            continue;
+        }
+
+        let Some(published_container_port) = published_port
+            .get("containerPort")
+            .and_then(json_value_as_u16)
+        else {
+            continue;
+        };
+        if published_container_port != container_port {
+            continue;
+        }
+
+        if let Some(host_port) = published_port.get("hostPort").and_then(json_value_as_u16) {
+            return Ok(host_port);
+        }
+        if let Some(host_port) = published_port
+            .get("hostPort")
+            .and_then(serde_json::Value::as_str)
+        {
+            return host_port.parse::<u16>().map_err(|source| {
+                ReadHostTcpPortError::InvalidHostPort {
+                    value: host_port.to_string(),
+                    source,
+                }
+            });
+        }
+    }
+
+    Err(ReadHostTcpPortError::NotPublished { container_port })
+}
+
+fn json_value_as_u16(value: &serde_json::Value) -> Option<u16> {
+    value
+        .as_u64()
+        .and_then(|value| u16::try_from(value).ok())
+        .or_else(|| value.as_str().and_then(|value| value.parse::<u16>().ok()))
+}
+
 /// Shared classification of a `docker run` / `podman run` failure, used by
 /// both [`Definition::run`] and [`Definition::run_detached`].
 #[derive(Debug, thiserror::Error)]
 pub enum RunError {
+    #[error("apple run does not support option {option}")]
+    UnsupportedOption { option: &'static str },
+
     /// Subprocess could not be started (binary missing, permissions, etc.).
     #[error("docker/podman run command IO failure")]
     Io(#[source] std::io::Error),
@@ -1225,10 +1356,13 @@ impl<'a> ExecCommand<'a> {
     /// …) rather than picking a pre-baked run method.
     #[must_use]
     pub fn to_cmd_proc_command(&self) -> Command {
-        let command = self
-            .container
-            .backend_command()
-            .arguments(["container", "exec"]);
+        let command = match &self.container.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => self
+                .container
+                .backend_command()
+                .arguments(["container", "exec"]),
+            Backend::Apple { .. } => self.container.backend_command().argument("exec"),
+        };
 
         let command = self.tty.apply(command);
         let command = self.interactive.apply(command);
@@ -1271,8 +1405,14 @@ impl Container {
     /// decide how to handle failure (best-effort cleanup paths typically
     /// log and continue; transactional callers propagate).
     pub async fn stop(&mut self) -> Result<(), CommandError> {
-        self.backend_command()
-            .arguments(["container", "stop"])
+        let command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => {
+                self.backend_command().arguments(["container", "stop"])
+            }
+            Backend::Apple { .. } => self.backend_command().argument("stop"),
+        };
+
+        command
             .argument(&self.id)
             .stdout_capture()
             .bytes()
@@ -1295,7 +1435,12 @@ impl Container {
     }
 
     async fn do_remove(&mut self, force: bool) -> Result<(), CommandError> {
-        let mut command = self.backend_command().arguments(["container", "rm"]);
+        let mut command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => {
+                self.backend_command().arguments(["container", "rm"])
+            }
+            Backend::Apple { .. } => self.backend_command().argument("delete"),
+        };
         if force {
             command = command.argument("--force");
         }
@@ -1339,28 +1484,33 @@ impl Container {
     ) -> Result<u16, ReadHostTcpPortError> {
         let value = self.inspect().await?;
 
-        let host_port_str = value
-            .get("NetworkSettings")
-            .and_then(|network_settings| network_settings.get("Ports"))
-            .and_then(|ports| ports.get(format!("{container_port}/tcp")))
-            .and_then(|bindings| bindings.get(0))
-            .and_then(|binding| binding.get("HostPort"))
-            .and_then(|host_port| host_port.as_str())
-            .ok_or(ReadHostTcpPortError::NotPublished { container_port })?;
+        match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => {
+                let host_port_str = value
+                    .get("NetworkSettings")
+                    .and_then(|network_settings| network_settings.get("Ports"))
+                    .and_then(|ports| ports.get(format!("{container_port}/tcp")))
+                    .and_then(|bindings| bindings.get(0))
+                    .and_then(|binding| binding.get("HostPort"))
+                    .and_then(|host_port| host_port.as_str())
+                    .ok_or(ReadHostTcpPortError::NotPublished { container_port })?;
 
-        host_port_str
-            .parse::<u16>()
-            .map_err(|source| ReadHostTcpPortError::InvalidHostPort {
-                value: host_port_str.to_string(),
-                source,
-            })
+                host_port_str.parse::<u16>().map_err(|source| {
+                    ReadHostTcpPortError::InvalidHostPort {
+                        value: host_port_str.to_string(),
+                        source,
+                    }
+                })
+            }
+            Backend::Apple { .. } => read_apple_host_tcp_port(&value, container_port),
+        }
     }
 
     pub async fn commit(
         &self,
         reference: &image::Reference,
         pause: bool,
-    ) -> Result<(), CommandError> {
+    ) -> Result<(), CommitError> {
         let pause_argument = match (&self.backend, pause) {
             (Backend::Docker { .. }, true) => None,
             (Backend::Docker { version, .. }, false) => {
@@ -1374,6 +1524,9 @@ impl Container {
             }
             (Backend::Podman { .. }, true) => Some("--pause"),
             (Backend::Podman { .. }, false) => None,
+            (Backend::Apple { .. }, _) => {
+                return Err(CommitError::Unsupported);
+            }
         };
 
         self.backend_command()
@@ -1383,6 +1536,7 @@ impl Container {
             .argument(reference.to_string())
             .status()
             .await
+            .map_err(CommitError::Command)
     }
 
     fn backend_command(&self) -> Command {
@@ -1393,6 +1547,42 @@ impl Container {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_apple_host_tcp_port_from_published_ports() {
+        let value = serde_json::json!({
+            "configuration": {
+                "publishedPorts": [{
+                    "hostAddress": "127.0.0.1",
+                    "hostPort": 49152,
+                    "containerPort": 8080,
+                    "proto": "tcp"
+                }]
+            }
+        });
+
+        assert_eq!(read_apple_host_tcp_port(&value, 8080).unwrap(), 49152);
+    }
+
+    #[test]
+    fn read_apple_host_tcp_port_rejects_unpublished_port() {
+        let value = serde_json::json!({
+            "configuration": {
+                "publishedPorts": [{
+                    "hostPort": 49152,
+                    "containerPort": 8080,
+                    "proto": "tcp"
+                }]
+            }
+        });
+
+        assert!(matches!(
+            read_apple_host_tcp_port(&value, 5432),
+            Err(ReadHostTcpPortError::NotPublished {
+                container_port: 5432
+            })
+        ));
+    }
 
     #[test]
     fn container_name_accepts_valid() {

--- a/ociman/src/container.rs
+++ b/ociman/src/container.rs
@@ -1561,14 +1561,19 @@ impl Container {
             AppleCommitLabels::from_inspect_and_container(&source_image_inspect, container_labels);
 
         let context = AppleCommitContext::new(&config);
-        self.backend_command()
+        if let Err(error) = self
+            .backend_command()
             .argument("export")
             .argument("--output")
             .argument(context.rootfs_path())
             .argument(&self.id)
             .status()
             .await
-            .map_err(CommitError::Command)?;
+            .map_err(CommitError::Command)
+        {
+            context.cleanup();
+            return Err(error);
+        }
 
         let command = labels.apply_build_arguments(self.backend_command().arguments([
             "build",
@@ -1576,12 +1581,15 @@ impl Container {
             "--tag",
             &reference.to_string(),
         ]));
-        let _apple_build_guard = crate::backend::apple_build_lock();
-        command
+        let apple_build_guard = crate::backend::apple_build_lock();
+        let result = command
             .argument(context.path())
             .status()
             .await
-            .map_err(CommitError::Command)
+            .map_err(CommitError::Command);
+        apple_build_guard.release();
+        context.cleanup();
+        result
     }
 
     async fn apple_inspect_source_image(
@@ -1786,11 +1794,9 @@ impl AppleCommitContext {
     fn rootfs_path(&self) -> std::path::PathBuf {
         self.path.join("rootfs.tar")
     }
-}
 
-impl Drop for AppleCommitContext {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.path);
+    fn cleanup(self) {
+        let _ = std::fs::remove_dir_all(self.path);
     }
 }
 

--- a/ociman/src/container.rs
+++ b/ociman/src/container.rs
@@ -1020,8 +1020,12 @@ impl InspectError {
 pub enum CommitError {
     #[error("failed to inspect container before Apple commit emulation")]
     Inspect(#[source] InspectError),
+    #[error("failed to inspect source image before Apple commit emulation")]
+    SourceImageInspect(#[source] InspectError),
     #[error("Apple container inspect output did not include the source image reference")]
     MissingAppleBaseImage,
+    #[error("Apple source image inspect output did not include an OCI image config")]
+    MissingAppleImageConfig,
     #[error(transparent)]
     Command(#[from] CommandError),
 }
@@ -1548,11 +1552,15 @@ impl Container {
             .pointer("/configuration/image/reference")
             .and_then(serde_json::Value::as_str)
             .ok_or(CommitError::MissingAppleBaseImage)?;
-        let labels = inspect
+        let container_labels = inspect
             .pointer("/configuration/labels")
             .and_then(serde_json::Value::as_object);
+        let source_image_inspect = self.apple_inspect_source_image(base_image).await?;
+        let config = AppleCommitImageConfig::from_inspect(&source_image_inspect)?;
+        let labels =
+            AppleCommitLabels::from_inspect_and_container(&source_image_inspect, container_labels);
 
-        let context = AppleCommitContext::new(base_image);
+        let context = AppleCommitContext::new(&config);
         self.backend_command()
             .argument("export")
             .argument("--output")
@@ -1562,23 +1570,12 @@ impl Container {
             .await
             .map_err(CommitError::Command)?;
 
-        let mut command = self.backend_command().arguments([
+        let command = labels.apply_build_arguments(self.backend_command().arguments([
             "build",
             "--no-cache",
             "--tag",
             &reference.to_string(),
-        ]);
-        if let Some(labels) = labels {
-            for (key, value) in labels {
-                if let Some(value) = value.as_str() {
-                    command = command.argument("--label").argument(format!(
-                        "{}=ociman-apple-hex:{}",
-                        key,
-                        hex::encode(crate::label::apple_decode_value(value))
-                    ));
-                }
-            }
-        }
+        ]));
         let _apple_build_guard = crate::backend::apple_build_lock();
         command
             .argument(context.path())
@@ -1587,9 +1584,173 @@ impl Container {
             .map_err(CommitError::Command)
     }
 
+    async fn apple_inspect_source_image(
+        &self,
+        reference: &str,
+    ) -> Result<serde_json::Value, CommitError> {
+        let result = self
+            .backend_command()
+            .arguments(["image", "inspect", reference])
+            .stdout_capture()
+            .stderr_capture()
+            .accept_nonzero_exit()
+            .run()
+            .await
+            .map_err(|error| match error {
+                cmd_proc::CommandError::Io(io) => {
+                    CommitError::SourceImageInspect(InspectError::Io(io))
+                }
+                cmd_proc::CommandError::ExitStatus(exit_status) => {
+                    CommitError::SourceImageInspect(InspectError::Subprocess {
+                        exit_status,
+                        stderr: String::new(),
+                    })
+                }
+            })?;
+
+        if !result.status.success() {
+            return Err(CommitError::SourceImageInspect(
+                InspectError::classify_failure(result.status, &result.stderr),
+            ));
+        }
+
+        let value: serde_json::Value = serde_json::from_slice(&result.stdout)
+            .map_err(|error| CommitError::SourceImageInspect(InspectError::Parse(error)))?;
+        match value {
+            serde_json::Value::Array(values) => Ok(values.into_iter().next().unwrap()),
+            value => Ok(value),
+        }
+    }
+
     fn backend_command(&self) -> Command {
         self.backend.command()
     }
+}
+
+#[derive(Default)]
+struct AppleCommitImageConfig {
+    env: Vec<String>,
+    entrypoint: Option<Vec<String>>,
+    cmd: Option<Vec<String>>,
+    workdir: Option<String>,
+    user: Option<String>,
+}
+
+impl AppleCommitImageConfig {
+    fn from_inspect(value: &serde_json::Value) -> Result<Self, CommitError> {
+        let config = find_apple_image_config(value).ok_or(CommitError::MissingAppleImageConfig)?;
+        Ok(Self {
+            env: read_string_array(config, &["Env", "env"]).unwrap_or_default(),
+            entrypoint: read_string_array(config, &["Entrypoint", "entrypoint"]),
+            cmd: read_string_array(config, &["Cmd", "cmd"]),
+            workdir: read_string(config, &["WorkingDir", "workingDir"]),
+            user: read_string(config, &["User", "user"]),
+        })
+    }
+
+    fn dockerfile_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for variable in &self.env {
+            if let Some((key, value)) = variable.split_once('=') {
+                lines.push(format!("ENV {key}={}", dockerfile_quoted(value)));
+            }
+        }
+        if let Some(workdir) = self.workdir.as_deref().filter(|value| !value.is_empty()) {
+            lines.push(format!("WORKDIR {}", dockerfile_quoted(workdir)));
+        }
+        if let Some(user) = self.user.as_deref().filter(|value| !value.is_empty()) {
+            lines.push(format!("USER {}", dockerfile_quoted(user)));
+        }
+        if let Some(entrypoint) = self.entrypoint.as_ref().filter(|value| !value.is_empty()) {
+            lines.push(format!(
+                "ENTRYPOINT {}",
+                serde_json::to_string(entrypoint).expect("string arrays serialize")
+            ));
+        }
+        if let Some(cmd) = self.cmd.as_ref().filter(|value| !value.is_empty()) {
+            lines.push(format!(
+                "CMD {}",
+                serde_json::to_string(cmd).expect("string arrays serialize")
+            ));
+        }
+        lines
+    }
+}
+
+struct AppleCommitLabels(std::collections::BTreeMap<String, String>);
+
+impl AppleCommitLabels {
+    fn from_inspect_and_container(
+        source_image: &serde_json::Value,
+        container_labels: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Self {
+        let mut labels = std::collections::BTreeMap::new();
+        if let Ok(image_labels) =
+            crate::label::decode_labels::<crate::label::scope::Image>(source_image)
+        {
+            for (key, value) in image_labels.iter() {
+                labels.insert(key.as_str().to_string(), value.as_str().to_string());
+            }
+        }
+        if let Some(container_labels) = container_labels {
+            for (key, value) in container_labels {
+                if let Some(value) = value.as_str() {
+                    labels.insert(key.clone(), crate::label::apple_decode_value(value));
+                }
+            }
+        }
+        Self(labels)
+    }
+
+    fn build_arguments(&self) -> Vec<String> {
+        self.0
+            .iter()
+            .map(|(key, value)| format!("{}=ociman-apple-hex:{}", key, hex::encode(value)))
+            .collect()
+    }
+
+    fn apply_build_arguments(&self, command: Command) -> Command {
+        self.build_arguments()
+            .into_iter()
+            .fold(command, |command, label| {
+                command.argument("--label").argument(label)
+            })
+    }
+}
+
+fn find_apple_image_config(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    [
+        "/variants/0/config/config",
+        "/config/config",
+        "/Config",
+        "/config",
+    ]
+    .into_iter()
+    .find_map(|pointer| value.pointer(pointer))
+    .filter(|value| value.is_object())
+}
+
+fn read_string(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| value.get(*key))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn read_string_array(value: &serde_json::Value, keys: &[&str]) -> Option<Vec<String>> {
+    let array = keys
+        .iter()
+        .find_map(|key| value.get(*key))
+        .and_then(serde_json::Value::as_array)?;
+    array
+        .iter()
+        .map(|value| value.as_str().map(str::to_string))
+        .collect()
+}
+
+fn dockerfile_quoted(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
 }
 
 struct AppleCommitContext {
@@ -1597,7 +1758,7 @@ struct AppleCommitContext {
 }
 
 impl AppleCommitContext {
-    fn new(base_image: &str) -> Self {
+    fn new(config: &AppleCommitImageConfig) -> Self {
         let mut path = std::env::temp_dir();
         path.push(format!(
             "ociman-apple-commit-{}-{}",
@@ -1608,11 +1769,13 @@ impl AppleCommitContext {
                 .as_nanos()
         ));
         std::fs::create_dir(&path).expect("failed to create Apple commit context");
-        std::fs::write(
-            path.join("Dockerfile"),
-            format!("FROM {base_image}\nADD rootfs.tar /\n"),
-        )
-        .expect("failed to write Apple commit Dockerfile");
+        let mut dockerfile = String::from("FROM scratch\nADD rootfs.tar /\n");
+        for line in config.dockerfile_lines() {
+            dockerfile.push_str(&line);
+            dockerfile.push('\n');
+        }
+        std::fs::write(path.join("Dockerfile"), dockerfile)
+            .expect("failed to write Apple commit Dockerfile");
         Self { path }
     }
 
@@ -1634,6 +1797,71 @@ impl Drop for AppleCommitContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apple_commit_config_reads_apple_image_config() {
+        let value = serde_json::json!({
+            "variants": [{
+                "config": {
+                    "config": {
+                        "env": ["PATH=/usr/bin", "PGDATA=/var/lib/postgresql/data"],
+                        "entrypoint": ["docker-entrypoint.sh"],
+                        "cmd": ["postgres"],
+                        "workingDir": "/var/lib/postgresql",
+                        "user": "postgres"
+                    }
+                }
+            }]
+        });
+
+        let config = AppleCommitImageConfig::from_inspect(&value).unwrap();
+
+        assert_eq!(
+            config.dockerfile_lines(),
+            vec![
+                "ENV PATH=\"/usr/bin\"",
+                "ENV PGDATA=\"/var/lib/postgresql/data\"",
+                "WORKDIR \"/var/lib/postgresql\"",
+                "USER \"postgres\"",
+                "ENTRYPOINT [\"docker-entrypoint.sh\"]",
+                "CMD [\"postgres\"]",
+            ]
+        );
+    }
+
+    #[test]
+    fn apple_commit_labels_merge_container_over_image() {
+        let source_image = serde_json::json!({
+            "variants": [{
+                "config": {
+                    "config": {
+                        "labels": {
+                            "shared": "image",
+                            "image-only": "kept"
+                        }
+                    }
+                }
+            }]
+        });
+        let container_labels = serde_json::json!({
+            "shared": "ociman-apple-hex:636f6e7461696e6572",
+            "container-only": "ociman-apple-hex:6164646564"
+        });
+
+        let labels = AppleCommitLabels::from_inspect_and_container(
+            &source_image,
+            container_labels.as_object(),
+        );
+
+        assert_eq!(
+            labels.build_arguments(),
+            vec![
+                "container-only=ociman-apple-hex:6164646564",
+                "image-only=ociman-apple-hex:6b657074",
+                "shared=ociman-apple-hex:636f6e7461696e6572",
+            ]
+        );
+    }
 
     #[test]
     fn read_apple_host_tcp_port_from_published_ports() {

--- a/ociman/src/container.rs
+++ b/ociman/src/container.rs
@@ -888,7 +888,10 @@ impl Definition {
         };
         let command = self.name.apply(command);
         let command = self.environment_variables.apply(command);
-        let command = self.labels.apply(command);
+        let command = match &self.backend {
+            Backend::Docker { .. } | Backend::Podman { .. } => self.labels.apply(command),
+            Backend::Apple { .. } => self.labels.apply_apple(command),
+        };
         let command = match &self.backend {
             Backend::Docker { .. } | Backend::Podman { .. } => self.publish.apply(command),
             Backend::Apple { .. } => {
@@ -1015,8 +1018,10 @@ impl InspectError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum CommitError {
-    #[error("commit is unsupported on apple")]
-    Unsupported,
+    #[error("failed to inspect container before Apple commit emulation")]
+    Inspect(#[source] InspectError),
+    #[error("Apple container inspect output did not include the source image reference")]
+    MissingAppleBaseImage,
     #[error(transparent)]
     Command(#[from] CommandError),
 }
@@ -1524,9 +1529,7 @@ impl Container {
             }
             (Backend::Podman { .. }, true) => Some("--pause"),
             (Backend::Podman { .. }, false) => None,
-            (Backend::Apple { .. }, _) => {
-                return Err(CommitError::Unsupported);
-            }
+            (Backend::Apple { .. }, _) => return self.apple_commit(reference).await,
         };
 
         self.backend_command()
@@ -1539,8 +1542,92 @@ impl Container {
             .map_err(CommitError::Command)
     }
 
+    async fn apple_commit(&self, reference: &image::Reference) -> Result<(), CommitError> {
+        let inspect = self.inspect().await.map_err(CommitError::Inspect)?;
+        let base_image = inspect
+            .pointer("/configuration/image/reference")
+            .and_then(serde_json::Value::as_str)
+            .ok_or(CommitError::MissingAppleBaseImage)?;
+        let labels = inspect
+            .pointer("/configuration/labels")
+            .and_then(serde_json::Value::as_object);
+
+        let context = AppleCommitContext::new(base_image);
+        self.backend_command()
+            .argument("export")
+            .argument("--output")
+            .argument(context.rootfs_path())
+            .argument(&self.id)
+            .status()
+            .await
+            .map_err(CommitError::Command)?;
+
+        let mut command = self.backend_command().arguments([
+            "build",
+            "--no-cache",
+            "--tag",
+            &reference.to_string(),
+        ]);
+        if let Some(labels) = labels {
+            for (key, value) in labels {
+                if let Some(value) = value.as_str() {
+                    command = command.argument("--label").argument(format!(
+                        "{}=ociman-apple-hex:{}",
+                        key,
+                        hex::encode(crate::label::apple_decode_value(value))
+                    ));
+                }
+            }
+        }
+        let _apple_build_guard = crate::backend::apple_build_lock();
+        command
+            .argument(context.path())
+            .status()
+            .await
+            .map_err(CommitError::Command)
+    }
+
     fn backend_command(&self) -> Command {
         self.backend.command()
+    }
+}
+
+struct AppleCommitContext {
+    path: std::path::PathBuf,
+}
+
+impl AppleCommitContext {
+    fn new(base_image: &str) -> Self {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "ociman-apple-commit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock is before UNIX_EPOCH")
+                .as_nanos()
+        ));
+        std::fs::create_dir(&path).expect("failed to create Apple commit context");
+        std::fs::write(
+            path.join("Dockerfile"),
+            format!("FROM {base_image}\nADD rootfs.tar /\n"),
+        )
+        .expect("failed to write Apple commit Dockerfile");
+        Self { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    fn rootfs_path(&self) -> std::path::PathBuf {
+        self.path.join("rootfs.tar")
+    }
+}
+
+impl Drop for AppleCommitContext {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
     }
 }
 

--- a/ociman/src/image.rs
+++ b/ociman/src/image.rs
@@ -244,21 +244,31 @@ impl BuildDefinition {
             arguments.push(format!("{key}={value}"));
         }
 
+        let mut apple_instruction_context = None;
         let command = match &self.source {
             BuildSource::Directory(path) => {
                 arguments.push(path.to_string_lossy().into());
                 self.backend.command().arguments(arguments)
             }
-            BuildSource::Instructions(content) => {
-                arguments.push("-".into());
-                self.backend
-                    .command()
-                    .arguments(arguments)
-                    .stdin_bytes(content.as_bytes().to_vec())
-            }
+            BuildSource::Instructions(content) => match &self.backend {
+                Backend::Docker { .. } | Backend::Podman { .. } => {
+                    arguments.push("-".into());
+                    self.backend
+                        .command()
+                        .arguments(arguments)
+                        .stdin_bytes(content.as_bytes().to_vec())
+                }
+                Backend::Apple { .. } => {
+                    let context = AppleInstructionBuildContext::write(content);
+                    arguments.push(context.path().to_string_lossy().into());
+                    apple_instruction_context = Some(context);
+                    self.backend.command().arguments(arguments)
+                }
+            },
         };
 
         command.status().await.unwrap();
+        drop(apple_instruction_context);
 
         target_reference
     }
@@ -292,6 +302,37 @@ impl BuildDefinition {
                 }
             }
         }
+    }
+}
+
+struct AppleInstructionBuildContext {
+    path: PathBuf,
+}
+
+impl AppleInstructionBuildContext {
+    fn write(content: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "ociman-apple-build-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock is before UNIX_EPOCH")
+                .as_nanos()
+        ));
+        std::fs::create_dir(&path).expect("failed to create Apple build context");
+        std::fs::write(path.join("Dockerfile"), content)
+            .expect("failed to write Apple build Dockerfile");
+        Self { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for AppleInstructionBuildContext {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
     }
 }
 

--- a/ociman/src/image.rs
+++ b/ociman/src/image.rs
@@ -270,13 +270,18 @@ impl BuildDefinition {
             },
         };
 
-        let _apple_build_guard = match &self.backend {
+        let apple_build_guard = match &self.backend {
             Backend::Apple { .. } => Some(crate::backend::apple_build_lock()),
             Backend::Docker { .. } | Backend::Podman { .. } => None,
         };
-        command.status().await.unwrap();
-        drop(_apple_build_guard);
-        drop(apple_instruction_context);
+        let status_result = command.status().await;
+        if let Some(guard) = apple_build_guard {
+            guard.release();
+        }
+        if let Some(context) = apple_instruction_context {
+            context.cleanup();
+        }
+        status_result.unwrap();
 
         target_reference
     }
@@ -336,11 +341,9 @@ impl AppleInstructionBuildContext {
     fn path(&self) -> &std::path::Path {
         &self.path
     }
-}
 
-impl Drop for AppleInstructionBuildContext {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.path);
+    fn cleanup(self) {
+        let _ = std::fs::remove_dir_all(self.path);
     }
 }
 

--- a/ociman/src/image.rs
+++ b/ociman/src/image.rs
@@ -241,7 +241,10 @@ impl BuildDefinition {
 
         for (key, value) in self.labels.iter() {
             arguments.push("--label".into());
-            arguments.push(format!("{key}={value}"));
+            arguments.push(match &self.backend {
+                Backend::Docker { .. } | Backend::Podman { .. } => format!("{key}={value}"),
+                Backend::Apple { .. } => crate::label::apple_label_argument(key, value),
+            });
         }
 
         let mut apple_instruction_context = None;
@@ -267,7 +270,12 @@ impl BuildDefinition {
             },
         };
 
+        let _apple_build_guard = match &self.backend {
+            Backend::Apple { .. } => Some(crate::backend::apple_build_lock()),
+            Backend::Docker { .. } | Backend::Podman { .. } => None,
+        };
         command.status().await.unwrap();
+        drop(_apple_build_guard);
         drop(apple_instruction_context);
 
         target_reference

--- a/ociman/src/label.rs
+++ b/ociman/src/label.rs
@@ -244,6 +244,38 @@ impl Apply for Map {
     }
 }
 
+impl Map {
+    pub(crate) fn apply_apple(&self, command: Command) -> Command {
+        self.0.iter().fold(command, |command, (key, value)| {
+            command.argument("--label").argument(format!(
+                "{}={}",
+                key,
+                apple_encode_value(value.as_str())
+            ))
+        })
+    }
+}
+
+const APPLE_VALUE_PREFIX: &str = "ociman-apple-hex:";
+
+pub(crate) fn apple_label_argument(key: &Key, value: &Value) -> String {
+    format!("{}={}", key, apple_encode_value(value.as_str()))
+}
+
+fn apple_encode_value(value: &str) -> String {
+    format!("{APPLE_VALUE_PREFIX}{}", hex::encode(value))
+}
+
+pub(crate) fn apple_decode_value(value: &str) -> String {
+    let Some(hex_value) = value.strip_prefix(APPLE_VALUE_PREFIX) else {
+        return value.to_string();
+    };
+    hex::decode(hex_value)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .unwrap_or_else(|| value.to_string())
+}
+
 /// `--filter label=…` predicate for `container list` / `image list`.
 ///
 /// Matches containers/images carrying [`Self::key`], optionally narrowed to the
@@ -453,12 +485,15 @@ impl<S: Scope> ReadError<S> {
 pub(crate) fn decode_labels<S: Scope>(
     value: &serde_json::Value,
 ) -> Result<ReadLabels<S>, ReadError<S>> {
-    let labels_value = value
-        .get("Config")
-        .and_then(|config| config.get("Labels"))
-        .or_else(|| value.pointer("/configuration/labels"))
+    let docker_labels = value.get("Config").and_then(|config| config.get("Labels"));
+    let apple_labels = value
+        .pointer("/configuration/labels")
         .or_else(|| value.pointer("/variants/0/config/config/Labels"))
         .or_else(|| value.pointer("/variants/0/config/config/labels"));
+    let (labels_value, apple_encoded) = match (docker_labels, apple_labels) {
+        (Some(labels), _) => (Some(labels), false),
+        (None, labels) => (labels, true),
+    };
 
     let mut labels = ReadLabels::<S>::new();
 
@@ -478,10 +513,12 @@ pub(crate) fn decode_labels<S: Scope>(
         let value_str = value
             .as_str()
             .ok_or_else(|| ReadError::<S>::value_not_string(key.clone()))?;
-        labels.insert(
-            ReadKey::new(key.clone()),
-            ReadValue::new(value_str.to_string()),
-        );
+        let value = if apple_encoded {
+            apple_decode_value(value_str)
+        } else {
+            value_str.to_string()
+        };
+        labels.insert(ReadKey::new(key.clone()), ReadValue::new(value));
     }
 
     Ok(labels)

--- a/ociman/src/label.rs
+++ b/ociman/src/label.rs
@@ -453,7 +453,12 @@ impl<S: Scope> ReadError<S> {
 pub(crate) fn decode_labels<S: Scope>(
     value: &serde_json::Value,
 ) -> Result<ReadLabels<S>, ReadError<S>> {
-    let labels_value = value.get("Config").and_then(|config| config.get("Labels"));
+    let labels_value = value
+        .get("Config")
+        .and_then(|config| config.get("Labels"))
+        .or_else(|| value.pointer("/configuration/labels"))
+        .or_else(|| value.pointer("/variants/0/config/config/Labels"))
+        .or_else(|| value.pointer("/variants/0/config/config/labels"));
 
     let mut labels = ReadLabels::<S>::new();
 

--- a/ociman/src/lib.rs
+++ b/ociman/src/lib.rs
@@ -12,10 +12,10 @@ pub mod testing;
 
 pub use backend::{Backend, BridgeSubnetError, ContainerHostnameResolver, ResolveHostnameError};
 pub use container::{
-    Container, ContainerArgument, ContainerId, ContainerName, ContainerNameError, Definition,
-    Detach, Entrypoint, EnvironmentVariables, ExecCommand, InspectError, Mount, Protocol, Publish,
-    PullPolicy, ReadContainerNameError, ReadHostTcpPortError, Remove, RunDetachedError, RunError,
-    WithContainerError, Workdir,
+    CommitError, Container, ContainerArgument, ContainerId, ContainerName, ContainerNameError,
+    Definition, Detach, Entrypoint, EnvironmentVariables, ExecCommand, InspectError, Mount,
+    Protocol, Publish, PullPolicy, ReadContainerNameError, ReadHostTcpPortError, Remove,
+    RunDetachedError, RunError, WithContainerError, Workdir,
 };
 pub use image::{
     BuildArgumentKey, BuildArgumentKeyError, BuildArgumentValue, BuildDefinition, BuildSource,

--- a/ociman/src/platform.rs
+++ b/ociman/src/platform.rs
@@ -1,5 +1,7 @@
 //! Platform support detection for container-based tools
 
+use crate::backend::Selection;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// GitHub Actions on macOS does not support Docker
@@ -24,6 +26,9 @@ impl std::error::Error for Error {}
 const GITHUB_ACTIONS: cmd_proc::EnvVariableName =
     cmd_proc::EnvVariableName::from_static_or_panic("GITHUB_ACTIONS");
 
+const OCIMAN_BACKEND: cmd_proc::EnvVariableName =
+    cmd_proc::EnvVariableName::from_static_or_panic("OCIMAN_BACKEND");
+
 /// Check if the current platform supports container operations
 ///
 /// Returns `Ok(())` if the platform is supported, or an `Err` containing
@@ -38,7 +43,19 @@ const GITHUB_ACTIONS: cmd_proc::EnvVariableName =
 /// }
 /// ```
 pub fn support() -> Result<(), Error> {
-    if std::env::consts::OS == "macos" && GITHUB_ACTIONS.is_present() {
+    let backend = OCIMAN_BACKEND.read().ok().and_then(|value| {
+        if value.as_str() == "apple" {
+            Some(Selection::Apple)
+        } else {
+            None
+        }
+    });
+
+    support_for(std::env::consts::OS, GITHUB_ACTIONS.is_present(), backend)
+}
+
+fn support_for(os: &str, github_actions: bool, backend: Option<Selection>) -> Result<(), Error> {
+    if os == "macos" && github_actions && !matches!(backend, Some(Selection::Apple)) {
         Err(Error::GitHubActionsMacOs)
     } else {
         Ok(())
@@ -50,18 +67,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_platform_support_consistency() {
-        // This test is intentionally tautological - it verifies that the support()
-        // function's logic is consistent with itself by re-implementing the same check.
-        // While this doesn't validate correctness, it ensures that if someone modifies
-        // the platform detection logic in support(), they must also update this test,
-        // preventing silent breakage of the platform detection contract.
-        let expected = if std::env::consts::OS == "macos" && GITHUB_ACTIONS.is_present() {
+    fn github_actions_macos_is_skipped_for_docker() {
+        assert_eq!(
+            support_for("macos", true, Some(Selection::Docker)),
             Err(Error::GitHubActionsMacOs)
-        } else {
-            Ok(())
-        };
+        );
+    }
 
-        assert_eq!(support(), expected);
+    #[test]
+    fn github_actions_macos_is_not_skipped_for_explicit_apple() {
+        assert_eq!(support_for("macos", true, Some(Selection::Apple)), Ok(()));
+    }
+
+    #[test]
+    fn local_macos_is_supported() {
+        assert_eq!(support_for("macos", false, None), Ok(()));
     }
 }

--- a/ociman/src/testing.rs
+++ b/ociman/src/testing.rs
@@ -46,8 +46,10 @@ pub fn test_images() -> Vec<crate::image::Reference> {
 #[allow(clippy::test_attr_in_doctest)]
 /// Check if the current platform is not supported for container tests
 ///
-/// Returns `true` on macOS running in GitHub Actions, where container
-/// runtime is not available or reliable.
+/// Returns `true` on macOS running in GitHub Actions for Docker/Podman-style
+/// runs, where those container runtimes are not available or reliable. Explicit
+/// Apple backend runs are allowed to proceed so macOS 26 CI misconfiguration
+/// fails clearly.
 ///
 /// # Example
 ///

--- a/ociman/tests/integration.rs
+++ b/ociman/tests/integration.rs
@@ -712,30 +712,18 @@ async fn test_commit_propagates_container_labels() {
         backend.remove_image_force(&target).await;
     }
 
-    let definition = alpine_test_definition(&backend)
-        .entrypoint("sh")
-        .arguments(["-c", "trap 'exit 0' TERM; sleep 30 & wait"])
-        .label(&TEST_KEY, &TEST_VALUE);
+    let definition = ociman::Definition::new(
+        backend.clone(),
+        ociman::testing::ALPINE_LATEST_IMAGE.clone(),
+    )
+    .entrypoint("sh")
+    .arguments(["-c", "trap 'exit 0' TERM; sleep 30 & wait"])
+    .label(&TEST_KEY, &TEST_VALUE);
 
-    let target_for_commit = target.clone();
-    definition
-        .with_container(async |container| {
-            let result = container.commit(&target_for_commit, true).await;
-            if matches!(backend, ociman::Backend::Apple { .. }) {
-                assert!(matches!(
-                    result,
-                    Err(ociman::CommitError::Unsupported)
-                ));
-            } else {
-                result.unwrap();
-            }
-        })
-        .await
-        .unwrap();
-
-    if matches!(backend, ociman::Backend::Apple { .. }) {
-        return;
-    }
+    let mut container = definition.run_detached().await.unwrap();
+    container.stop().await.unwrap();
+    container.commit(&target, true).await.unwrap();
+    container.remove().await.unwrap();
 
     let labels = backend.image_labels(&target).await.unwrap();
 
@@ -919,35 +907,23 @@ async fn test_container_commit() {
         backend.remove_image(&target_reference).await;
     }
 
-    let definition = alpine_test_definition(&backend)
-        .entrypoint("sh")
-        .arguments(["-c", "trap 'exit 0' TERM; sleep 30 & wait"]);
+    let definition = ociman::Definition::new(
+        backend.clone(),
+        ociman::testing::ALPINE_LATEST_IMAGE.clone(),
+    )
+    .entrypoint("sh")
+    .arguments(["-c", "trap 'exit 0' TERM; sleep 30 & wait"]);
 
-    let commit_target = target_reference.clone();
-    definition
-        .with_container(async |container| {
-            container
-                .exec("touch")
-                .argument("/committed-file")
-                .status()
-                .await
-                .unwrap();
-            let result = container.commit(&commit_target, true).await;
-            if matches!(backend, ociman::Backend::Apple { .. }) {
-                assert!(matches!(
-                    result,
-                    Err(ociman::CommitError::Unsupported)
-                ));
-            } else {
-                result.unwrap();
-            }
-        })
+    let mut container = definition.run_detached().await.unwrap();
+    container
+        .exec("touch")
+        .argument("/committed-file")
+        .status()
         .await
         .unwrap();
-
-    if matches!(backend, ociman::Backend::Apple { .. }) {
-        return;
-    }
+    container.stop().await.unwrap();
+    container.commit(&target_reference, true).await.unwrap();
+    container.remove().await.unwrap();
 
     assert!(
         backend.is_image_present(&target_reference).await.unwrap(),

--- a/ociman/tests/integration.rs
+++ b/ociman/tests/integration.rs
@@ -720,10 +720,22 @@ async fn test_commit_propagates_container_labels() {
     let target_for_commit = target.clone();
     definition
         .with_container(async |container| {
-            container.commit(&target_for_commit, true).await.unwrap();
+            let result = container.commit(&target_for_commit, true).await;
+            if matches!(backend, ociman::Backend::Apple { .. }) {
+                assert!(matches!(
+                    result,
+                    Err(ociman::CommitError::Unsupported)
+                ));
+            } else {
+                result.unwrap();
+            }
         })
         .await
         .unwrap();
+
+    if matches!(backend, ociman::Backend::Apple { .. }) {
+        return;
+    }
 
     let labels = backend.image_labels(&target).await.unwrap();
 
@@ -920,10 +932,22 @@ async fn test_container_commit() {
                 .status()
                 .await
                 .unwrap();
-            container.commit(&commit_target, true).await.unwrap();
+            let result = container.commit(&commit_target, true).await;
+            if matches!(backend, ociman::Backend::Apple { .. }) {
+                assert!(matches!(
+                    result,
+                    Err(ociman::CommitError::Unsupported)
+                ));
+            } else {
+                result.unwrap();
+            }
         })
         .await
         .unwrap();
+
+    if matches!(backend, ociman::Backend::Apple { .. }) {
+        return;
+    }
 
     assert!(
         backend.is_image_present(&target_reference).await.unwrap(),

--- a/ociman/tests/integration.rs
+++ b/ociman/tests/integration.rs
@@ -947,6 +947,70 @@ async fn test_container_commit() {
 }
 
 #[tokio::test]
+async fn test_container_commit_chain_preserves_snapshot_deletions() {
+    let backend = ociman::test_backend_setup!();
+
+    let first_reference: ociman::image::Reference =
+        ociman::testing::test_reference("ociman-test-commit-chain-1:latest");
+    let second_reference: ociman::image::Reference =
+        ociman::testing::test_reference("ociman-test-commit-chain-2:latest");
+
+    for reference in [&first_reference, &second_reference] {
+        if backend.is_image_present(reference).await.unwrap() {
+            backend.remove_image(reference).await;
+        }
+    }
+
+    let first_definition = ociman::Definition::new(
+        backend.clone(),
+        ociman::testing::ALPINE_LATEST_IMAGE.clone(),
+    )
+    .entrypoint("sh")
+    .arguments(["-c", "trap 'exit 0' TERM; sleep 30 & wait"]);
+
+    let mut first_container = first_definition.run_detached().await.unwrap();
+    first_container
+        .exec("touch")
+        .argument("/committed-1")
+        .status()
+        .await
+        .unwrap();
+    first_container.stop().await.unwrap();
+    first_container
+        .commit(&first_reference, true)
+        .await
+        .unwrap();
+    first_container.remove().await.unwrap();
+
+    let second_definition = ociman::Definition::new(backend.clone(), first_reference.clone())
+        .entrypoint("sh")
+        .arguments(["-c", "trap 'exit 0' TERM; sleep 30 & wait"]);
+
+    let mut second_container = second_definition.run_detached().await.unwrap();
+    second_container
+        .exec("sh")
+        .arguments(["-c", "rm /committed-1 && touch /committed-2"])
+        .status()
+        .await
+        .unwrap();
+    second_container.stop().await.unwrap();
+    second_container
+        .commit(&second_reference, true)
+        .await
+        .unwrap();
+    second_container.remove().await.unwrap();
+
+    let verify_definition = test_definition(&backend, second_reference.clone())
+        .entrypoint("sh")
+        .arguments(["-c", "test ! -e /committed-1 && test -e /committed-2"]);
+
+    verify_definition.run().await.unwrap();
+
+    backend.remove_image(&second_reference).await;
+    backend.remove_image(&first_reference).await;
+}
+
+#[tokio::test]
 async fn test_is_container_present() {
     let backend = ociman::test_backend_setup!();
 

--- a/pg-ephemeral/src/cli.rs
+++ b/pg-ephemeral/src/cli.rs
@@ -67,6 +67,8 @@ pub enum Error {
     CurrentDir(#[source] std::io::Error),
     #[error(transparent)]
     TransparentWorkdir(#[from] crate::definition::TransparentWorkdirError),
+    #[error(transparent)]
+    Run(#[from] ociman::RunError),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -495,7 +497,7 @@ async fn run_bin(
         // interactive tools and stdin piping behave like a local install.
         .interactive()
         .tty_if_terminal()
-        .to_cmd_proc_command()
+        .to_cmd_proc_command()?
         .status()
         .await?;
     Ok(())

--- a/pg-ephemeral/src/cli/meta.rs
+++ b/pg-ephemeral/src/cli/meta.rs
@@ -13,6 +13,7 @@ impl Command {
                 let (kind, version) = match backend {
                     ociman::Backend::Docker { version, .. } => ("docker", version),
                     ociman::Backend::Podman { version, .. } => ("podman", version),
+                    ociman::Backend::Apple { version } => ("apple", version),
                 };
                 println!("Backend:  {kind} {version}");
                 println!("Rootless: {}", backend.is_rootless());

--- a/pg-ephemeral/src/container.rs
+++ b/pg-ephemeral/src/container.rs
@@ -106,7 +106,7 @@ pub enum Error {
     Commit {
         reference: ociman::Reference,
         #[source]
-        source: cmd_proc::CommandError,
+        source: ociman::CommitError,
     },
 }
 

--- a/pg-ephemeral/src/definition.rs
+++ b/pg-ephemeral/src/definition.rs
@@ -526,6 +526,14 @@ impl Definition {
                 return Ok((previous_cache_reference.cloned(), remaining));
             };
 
+            if matches!(self.backend, ociman::Backend::Apple { .. })
+                && previous_cache_reference.is_some()
+            {
+                let mut remaining = vec![seed.clone()];
+                remaining.extend(seeds_iter.map(|(_, seed)| seed.clone()));
+                return Ok((previous_cache_reference.cloned(), remaining));
+            }
+
             // Under the build lock the status loaded earlier may be stale: a
             // peer could have built this layer while we waited. Re-stat to pick
             // it up. Without the lock nothing is being built, so the loaded

--- a/pg-ephemeral/tests/cache.rs
+++ b/pg-ephemeral/tests/cache.rs
@@ -611,7 +611,7 @@ const CONTAINERS_REGISTRIES_CONF: cmd_proc::EnvVariableName =
     cmd_proc::EnvVariableName::from_static_or_panic("CONTAINERS_REGISTRIES_CONF");
 
 /// Absolute path to the committed `registries.conf` fixture that marks the
-/// local test registry (`localhost:5000`) insecure.
+/// local test registry (`localhost:5001`) insecure.
 fn insecure_registries_conf() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/registries.conf")
 }
@@ -648,19 +648,22 @@ async fn run_pg_ephemeral_insecure(args: &[&str], current_dir: &std::path::Path)
 
 /// End-to-end push/pull round trip against a throwaway local registry.
 ///
-/// Boots `registry:2` on `localhost:5000`, points `cache_registry` at it,
-/// then runs: populate (build local cache) -> push (upload) -> reset
+/// Boots `registry:2`, exposing its container-side port 5000 on host port
+/// `localhost:5001`, points `cache_registry` at the host port, then runs:
+/// populate (build local cache) -> push (upload) -> reset
 /// --force (clear local) -> assert the stage is a miss -> pull (walk back
 /// from the tip) -> assert it's a local hit again. The registry needs no
 /// auth; podman is steered to plain HTTP via the insecure-registry fixture
-/// (see [`run_pg_ephemeral_insecure`]) and docker trusts loopback natively,
-/// so this runs in the normal suite — no credentials, no external
-/// dependency.
+/// (see [`run_pg_ephemeral_insecure`]), docker trusts loopback natively, and
+/// the ociman Apple backend selects Apple's explicit HTTP registry scheme for
+/// loopback registry references.
 #[tokio::test]
 async fn test_cache_registry_round_trip() {
-    // Fixed host port so the committed `registries.conf` fixture can name
-    // it; `registry:2` listens on this port inside the container too.
-    const REGISTRY_PORT: u16 = 5000;
+    // `registry:2` listens on port 5000 inside the container. Use 5001 on
+    // the host to avoid common macOS conflicts on localhost:5000, such as
+    // AirPlay Receiver.
+    const REGISTRY_CONTAINER_PORT: u16 = 5000;
+    const REGISTRY_HOST_PORT: u16 = 5001;
 
     let backend = ociman::test_backend_setup!();
 
@@ -670,13 +673,13 @@ async fn test_cache_registry_round_trip() {
     let registry_definition = ociman::Definition::new(backend.clone(), registry_image)
         .remove()
         .publish(
-            ociman::Publish::tcp(REGISTRY_PORT)
-                .host_ip_port(std::net::Ipv4Addr::LOCALHOST.into(), REGISTRY_PORT),
+            ociman::Publish::tcp(REGISTRY_CONTAINER_PORT)
+                .host_ip_port(std::net::Ipv4Addr::LOCALHOST.into(), REGISTRY_HOST_PORT),
         );
 
     registry_definition
         .with_container(async |_container| {
-            wait_registry_ready(REGISTRY_PORT).await;
+            wait_registry_ready(REGISTRY_HOST_PORT).await;
 
             let dir = TestDir::new("cache-registry-round-trip");
             dir.write_file("schema.sql", "CREATE TABLE users (id INTEGER PRIMARY KEY);");
@@ -684,7 +687,7 @@ async fn test_cache_registry_round_trip() {
                 "database.toml",
                 indoc::indoc! {r#"
                     image = "17.1"
-                    cache_registry = "localhost:5000/pg-ephemeral-cache-test"
+                    cache_registry = "localhost:5001/pg-ephemeral-cache-test"
 
                     [instances.main.seeds.schema]
                     type = "sql-file"
@@ -701,7 +704,7 @@ async fn test_cache_registry_round_trip() {
             // Same schema + image as `test_cache_status_deterministic`, and
             // `cache_registry` does not feed the cache key, so the hash is
             // that test's constant — only the registry prefix differs.
-            let cache_image = "localhost:5000/pg-ephemeral-cache-test/pg-ephemeral/main:\
+            let cache_image = "localhost:5001/pg-ephemeral-cache-test/pg-ephemeral/main:\
                 8732e9629a0030d0773d6b56db16cd6b9eb1b639bef6874f7c18df6094929c27";
 
             let after_reset = run_pg_ephemeral(&["cache", "status", "--json"], &dir.path).await;

--- a/pg-ephemeral/tests/fixtures/registries.conf
+++ b/pg-ephemeral/tests/fixtures/registries.conf
@@ -1,5 +1,5 @@
 # Test-only containers registries.conf for the cache-registry round-trip
-# test. The test boots `registry:2` on localhost:5000 serving plain HTTP;
+# test. The test boots `registry:2` on localhost:5001 serving plain HTTP;
 # podman otherwise defaults to HTTPS for localhost:<port> and fails the
 # push with "server gave HTTP response to HTTPS client". Marking the
 # registry insecure makes podman use HTTP and skip TLS verification.
@@ -8,5 +8,5 @@
 # push/pull subprocesses only. Docker ignores this file (it trusts
 # loopback registries natively), so the test works under both backends.
 [[registry]]
-location = "localhost:5000"
+location = "localhost:5001"
 insecure = true


### PR DESCRIPTION
## Summary

Adds a first-class `ociman` backend for [apple/container](https://github.com/apple/container) so `pg-ephemeral` can run on macOS 26 with Apple Container 1.0.0. The backend is intentionally compatibility-bounded: it preserves the public `ociman` API where Apple has matching runtime behavior, polyfills the small surface needed by `pg-ephemeral`, and fails early with domain errors when the Apple CLI has no safe equivalent.

Apple is not treated as a Docker CLI compatibility layer. The backend uses the released `container` CLI, parses Apple-native JSON, and exposes portability through typed `ociman` APIs.

See `ociman/APPLE_BACKEND.md` for the shipped backend design, command mapping, CI notes, known Apple Container issues, and rationale behind the workarounds.

## Design decisions

* Model Apple as a third `Backend` enum variant carrying only the detected Apple Container version. Apple has no Docker/Podman rootless/rootful split, so `is_rootless()` returns `false` for Apple.

* Keep Apple inspect/list JSON backend-specific. Portability comes from typed `ociman` APIs for labels, names, ports, presence checks, and network subnets rather than reshaping Apple JSON into Docker JSON.

* Select Apple explicitly with `OCIMAN_BACKEND=apple` or `default_backend = "apple"`. Auto-detection tries Docker, then Podman, then Apple last so Apple does not displace an existing Docker/Podman setup.

* Use the released `container` CLI as the integration boundary. Apple-specific command differences are handled at each operation instead of adding a template/rendering compatibility layer.

## Backend limitations and polyfills

* Label-filtered container listing is an ociman-side polyfill. Apple list JSON is parsed into typed records and filtered client-side for key-only and exact label matches because the released CLI does not expose Docker-style label filters.

* Inline image builds are an ociman-side fallback. Apple rejects stdin build contexts (`container build -`), so ociman writes inline instructions to a temporary `Dockerfile` context and builds that directory.

* Apple builds are serialized because Apple Container creates shared BuildKit state on demand and parallel cold-start builds can race on that singleton.

* Publish-any-host-port is an ociman-side fallback. Apple rejects empty host-port syntax, so ociman chooses a concrete loopback port before `container run`. That allocation can race another process binding the same port; a lost race surfaces as a normal bind failure and is not retried.

* `commit` is limited emulation, not native Apple Container behavior. Until Apple ships `container commit`, ociman exports the container filesystem and builds a new full-snapshot image from `scratch`, reconstructing only the OCI config fields needed to keep the snapshot runnable: environment, entrypoint, command, workdir, user, and labels. Container labels override source-image labels on key conflict so runtime cache metadata survives commit.

* Each Apple commit is a standalone filesystem snapshot rather than a diff layer. This is storage-heavy but supports repeated `pg-ephemeral` cache/seed commits without lower-layer resurrection when files are deleted between commits. Emulated commit builds use `--no-cache` to bound builder cache growth across repeated commits.

* Host reachability uses the default Apple network gateway parsed from `container network inspect default`; Docker/Podman host alias assumptions are not carried over.

* Loopback registry pushes pass Apple's explicit HTTP scheme flag because automatic scheme detection can choose the wrong protocol for throwaway local HTTP registries.

## CI

Apple integration runs as an `apple` lane in the existing `test` matrix. It uses the dedicated `aarch64-darwin` runner because hosted macOS runners are already VMs and do not provide the virtualization path Apple Container needs.

The lane starts `container system` and runs the ociman integration test serially with `OCIMAN_BACKEND=apple`.

