### PR TITLE
Fix explicit pg-ephemeral image references

### DIFF
--- a/pg-ephemeral/CHANGELOG.md
+++ b/pg-ephemeral/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Fully qualified OCI references are accepted for the `image` config field and
+  `--image` CLI flag, including tagged, digest-pinned, and `docker://` forms.
+
 ## 0.6.0
 
 ### Added

--- a/pg-ephemeral/README.md
+++ b/pg-ephemeral/README.md
@@ -91,11 +91,14 @@ cache = { type = "none" }
 
 | Field                    | Description                                                          |
 |--------------------------|----------------------------------------------------------------------|
-| `image`                  | PostgreSQL version / image tag (e.g. `"17.1"`)                       |
+| `image`                  | PostgreSQL version / tag (e.g. `"17.1"`) or qualified OCI reference (e.g. `"ghcr.io/myorg/postgres:17.1"`) |
 | `backend`                | `"docker"`, `"podman"`, or omit for auto-detection (see below)       |
 | `cache_registry`         | OCI registry prefix for cache images (e.g. `"ghcr.io/myorg"`). See [Sharing cache across machines](#sharing-cache-across-machines). |
 | `ssl_config`             | SSL configuration with `hostname` field ([example](https://github.com/mbj/mrs/tree/main/pg-ephemeral/examples/08-ssl)) |
 | `wait_available_timeout` | How long to wait for PostgreSQL to accept connections (e.g. `"30s"`) |
+
+Explicit OCI references must contain `/`. A `docker://` prefix also selects
+explicit-reference parsing and is omitted when the parsed image is displayed.
 
 ### Backend selection
 

--- a/pg-ephemeral/src/image.rs
+++ b/pg-ephemeral/src/image.rs
@@ -1,4 +1,4 @@
-/// Postgresql images supported, references images from <https://hub.docker.com/_/postgres>
+/// PostgreSQL image selection for official releases or explicit OCI references.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Image {
     /// Official release
@@ -211,11 +211,24 @@ impl std::str::FromStr for Image {
             alt((latest, release_candidate, official_release, os_only)).parse(input)
         }
 
-        match image(value).finish() {
+        let official_result = match image(value).finish() {
             Ok(("", result)) => Ok(result),
             Ok((remaining, _)) => Err(format!("unexpected trailing input: '{remaining}'")),
             Err(error) => Err(nom_language::error::convert_error(value, error)),
-        }
+        };
+
+        official_result.or_else(|official_error| {
+            let explicit_value = match value.strip_prefix("docker://") {
+                Some(explicit_value) => explicit_value,
+                None if value.contains('/') => value,
+                None => return Err(official_error),
+            };
+
+            explicit_value
+                .parse()
+                .map(Image::Explicit)
+                .map_err(|error| format!("invalid explicit image reference: {error}"))
+        })
     }
 }
 
@@ -445,6 +458,47 @@ mod test {
     fn assert_image(syntax: &str, expected: &Image) {
         assert_eq!(syntax.parse().as_ref(), Ok(expected), "parses: {syntax:#?}");
         assert_eq!(format!("{expected}"), syntax, "generates: {syntax:#?}");
+    }
+
+    #[test]
+    fn test_tagged_explicit_image_reference_parses_and_round_trips() {
+        assert_explicit_image(
+            "ghcr.io/mbj/postgres:18.3-pg-footgun",
+            "ghcr.io/mbj/postgres:18.3-pg-footgun",
+        );
+    }
+
+    #[test]
+    fn test_digest_explicit_image_reference_parses_and_round_trips() {
+        assert_explicit_image(
+            "ghcr.io/mbj/postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "ghcr.io/mbj/postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        );
+    }
+
+    #[test]
+    fn test_docker_transport_image_reference_parses_without_transport_prefix() {
+        assert_explicit_image(
+            "docker://ghcr.io/mbj/postgres:18.3-pg-footgun",
+            "ghcr.io/mbj/postgres:18.3-pg-footgun",
+        );
+    }
+
+    #[test]
+    fn test_invalid_explicit_image_reference_reports_reference_parse_error() {
+        let error = "ghcr.io/mbj/postgres:".parse::<Image>().unwrap_err();
+        let expected = "invalid explicit image reference: parse error: Parsing Error: Error { input: \":\", code: Eof }";
+        assert_eq!(error, expected);
+    }
+
+    fn assert_explicit_image(syntax: &str, canonical: &str) {
+        let expected = Image::Explicit(
+            canonical
+                .parse()
+                .expect("canonical explicit image reference must parse"),
+        );
+        assert_eq!(syntax.parse(), Ok(expected.clone()), "parses: {syntax:#?}");
+        assert_eq!(expected.to_string(), canonical, "generates: {syntax:#?}");
     }
 
     #[test]


### PR DESCRIPTION
`Image::Explicit` already exists, but `Image::from_str` only tries the official PostgreSQL shorthand grammar. I hit this while pointing Outerface at the pg-footgun image:

```text
Error: Decoding as toml failed: TOML parse error at line 4, column 9
  |
4 | image = "ghcr.io/mbj/postgres:18.3-pg-footgun"
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unexpected trailing input: '/mbj/postgres:18.3-pg-footgun'
```

I reproduced it through both `database.toml` and `--image` on pg-ephemeral 0.5.1 and 0.6.0 with all three forms we need:

- `ghcr.io/mbj/postgres:18.3-pg-footgun`
- `ghcr.io/mbj/postgres@sha256:b751027c7aa002db2df5d1382dff8e6d56d013d11b859e2b57d68d6cc250bb5b`
- `docker://ghcr.io/mbj/postgres:18.3-pg-footgun`

This falls back to `ociman::image::Reference` for qualified references after the shorthand parser rejects them. `docker://` is accepted as an explicit transport marker and removed from the canonical representation. The qualification guard keeps ambiguous shorthand mistakes such as `17rc` as shorthand errors. Malformed qualified references report the reference parser's error instead of an unrelated shorthand error.

The README and changelog now document the accepted forms. Tests cover tagged, digest-pinned, `docker://`, invalid explicit, and preserved shorthand cases.

Validation:

- mrs native floor passed: fmt, workspace release build, clippy, doctests, repository lint, and generated-file checks
- pg-ephemeral nextest: 164 passed; `test_cache_registry_round_trip` was excluded locally because macOS AirPlay owns IPv6 `localhost:5000`, while Linux CI runs the ociman lane
- cargo-mutants: 3/3 caught
- Outerface with the patched binary: SQL 229/229 and Jest 642 suites / 8,852 tests

The end-to-end pg-footgun run also confirmed the setting name is `join_collapse_limit_excess`, not `join_collapse_excess`. With that correction, Outerface passed at limit 20 with the excess action set to `error`.
